### PR TITLE
Fix README references [warmup pr]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to pi-agenticoding
+
+Welcome! This project welcomes focused, well-validated contributions. Use coding agents deliberately: research before editing, keep changes small, follow existing patterns, and document the validation you ran.
+
+## Development Principles
+
+- **Use code research first** — understand the surrounding module responsibilities before editing.
+- **Make minimal changes** — prefer targeted edits that reuse existing mechanisms.
+- **Match existing patterns** — keep naming, lifecycle hooks, tool contracts, and TUI behavior consistent with the current code.
+- **Preserve context-management semantics** — changes to `spawn`, `ledger`, or `handoff` should keep the agent workflow predictable across session resets and compaction.
+- **AI-agent generated contributions are welcome** — include enough human intent and validation context in the PR for reviewers to trust the result.
+
+## Suggested Workflow
+
+1. **Research the area**
+   - Identify the relevant primitive: spawn, ledger, handoff, watchdog, or extension wiring.
+   - Read nearby tests in `agenticoding.test.ts` before changing behavior.
+
+2. **Plan the smallest safe change**
+   - Reuse existing state and lifecycle hooks when possible.
+   - Avoid adding dependencies unless the change clearly needs them.
+
+3. **Implement with tests or validation**
+   - Add or update tests for behavior changes.
+   - For documentation-only changes, review rendered links and examples.
+
+4. **Submit a focused PR**
+   - Explain why the change is needed.
+   - Link the related issue or discussion when one exists.
+   - List the validation you ran, or explain why a test command was not applicable.
+
+## Quality Bar
+
+Before submitting, check that your change:
+
+- Keeps public tool names and contracts stable unless the PR explicitly proposes a breaking change.
+- Does not introduce hidden context growth, unbounded output, or recursive child-agent spawning.
+- Handles reset, cancellation, and stale-session cases where relevant.
+- Keeps docs aligned with the package version and installed behavior.
+
+## Community
+
+Use GitHub Issues for bug reports and feature requests. Keep discussions concrete: describe the agent workflow you expected, what happened instead, and any reproduction steps.
+
+## License
+
+By contributing to this project, you agree that your contributions will be licensed under the same MIT License as pi-agenticoding.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pi-agenticoding
 
 [![pi.dev package](https://img.shields.io/badge/pi.dev-package-purple)](https://pi.dev/packages/pi-agenticoding)
-[![npm version](https://img.shields.io/badge/npm-0.1.0-blue)](https://www.npmjs.com/package/pi-agenticoding)
+[![npm version](https://img.shields.io/badge/npm-0.2.0-blue)](https://www.npmjs.com/package/pi-agenticoding)
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 ![Status](https://img.shields.io/badge/status-active-brightgreen)
 
@@ -108,7 +108,7 @@ Delegate messy work to an isolated child agent with clean context. The child inh
 
 ### Ledger — Continuity Across Cuts
 
-A sparse continuity cache the agent curates while working. After discovering something reusable — a fact, constraint, decision, or expensive finding — it saves a named entry. Later contexts fetch entries on demand instead of re-deriving the work. The ledger persists across handoffs, context resets, and session restarts.
+A sparse continuity cache the agent curates while working. After discovering something reusable — a fact, constraint, decision, or expensive finding — it saves a named entry. Later contexts fetch entries on demand instead of re-deriving the work. **The ledger persists across handoffs and existing-session restarts; starting a new session with `/new` resets it.**
 
 ### Handoff — Deliberate Compaction
 
@@ -190,18 +190,11 @@ interface AgenticodingState {
 
 </details>
 
-<details>
-<summary><strong>Deep dive → ARCHITECTURE.md</strong></summary>
-
-See [ARCHITECTURE.md](ARCHITECTURE.md) for full module breakdown, tool schemas, lifecycle wiring, spawn child-session lifecycle, and ledger rehydration algorithm.
-
-</details>
-
 ---
 
 ## Contributing
 
-Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
+Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the project workflow and quality expectations.
 
 ## License
 


### PR DESCRIPTION
## Summary
- update the README npm badge to match `package.json` version `0.2.0`
- remove the README link to absent `ARCHITECTURE.md`
- add project-specific contributor guidance and point the README at `CONTRIBUTING.md`
- clarify that ledger entries persist across handoffs and existing-session restarts, while `/new` resets them

## Verification
- `git -C pi-agenticoding diff --name-only origin/main...HEAD`
- README local-link scan: `All local README link targets exist.`
- README badge/link-marker check: `README badge and required link markers are correct.`
