### PR TITLE
feat(notebook): rename ledger to notebook with subject-oriented grounding and add topic-awareness layerRefactor/notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 ![Status](https://img.shields.io/badge/status-active-brightgreen)
 
-**A Pi extension that gives the LLM tools to manage its own context.** `spawn`, `ledger`, and `handoff` let the agent actively isolate work, persist reusable knowledge, and restart clean — without platform compaction or manual copy-paste.
+**A Pi extension that gives the LLM tools to manage its own context.** `spawn`, `notebook`, and `handoff` let the agent actively isolate work, persist reusable knowledge, and restart clean — without platform compaction or manual copy-paste.
 
 ---
 
@@ -40,7 +40,7 @@ Then disable pi's built-in compaction so handoff stays in control:
 }
 ```
 
-That's it. Your agent now has `spawn`, `ledger_add`, `ledger_get`, `ledger_list`, and `handoff`. The status bar shows context usage and ledger count.
+That's it. Your agent now has `spawn`, `notebook_write`, `notebook_read`, `notebook_index`, and `handoff`. The status bar shows context usage and notebook count.
 
 ---
 
@@ -49,10 +49,10 @@ That's it. Your agent now has `spawn`, `ledger_add`, `ledger_get`, `ledger_list`
 | Feature | What it looks like |
 |---------|-------------------|
 | **Context usage %** | `ctx 65%` in status bar — green < 30%, yellow < 50%, orange < 70%, red ≥ 70% |
-| **Ledger count** | 📒 `3` when entries exist, hidden when empty |
+| **Notebook count** | 📒 `3` when pages exist, dim `📒 0` when empty |
 | **`/handoff` command** | Instant pivot — agent drafts brief, compacts context, resumes |
-| **`/ledger` command** | Overlay showing all entries with previews |
-| **Auto-rehydration** | Ledger entries survive session restarts |
+| **`/notebook` command** | Overlay showing all notebook pages with previews |
+| **Auto-rehydration** | Notebook pages survive session restarts |
 | **Spawn transparency** | Watch child agents work in real time in the TUI |
 | **Token cost visibility** | Each spawn reports input/output tokens, cache hits, and cost |
 | **No polling** | Writes serialized via a process-local lock — no race conditions |
@@ -86,17 +86,17 @@ You: "Add OAuth to the backend"
   spawn("audit current auth code")
          │
          ▼
-  ledger_add("oauth-decisions", "Flow: PKCE. Scope: read+write.")
+  notebook_write("oauth-decisions", "Flow: PKCE. Scope: read+write.")
          │
          ├── spawn("implement token endpoint")
          └── spawn("write tests")
          │
          ▼
   handoff("Wire OAuth routes into the middleware stack.
-           Ledger 'oauth-decisions' holds the constraints.")
+           Notebook page 'oauth-decisions' holds the constraints.")
 ```
 
-The agent decided to spawn research children, save reusable findings to the ledger, delegate implementation subtasks, and handoff when context got noisy. **You said one sentence.**
+The agent decided to spawn research children, save reusable findings to the notebook, delegate implementation subtasks, and handoff when context got noisy. **You said one sentence.**
 
 ---
 
@@ -106,15 +106,15 @@ The agent decided to spawn research children, save reusable findings to the ledg
 
 Delegate messy work to an isolated child agent with clean context. The child inherits the parent's model and tools, works independently, and returns only the condensed result. Siblings run in parallel; the parent stays focused on orchestration. Children cannot spawn grandchildren (explosive branch prevention).
 
-### Ledger — Continuity Across Cuts
+### Notebook — Continuity Across Cuts
 
-A sparse continuity cache the agent curates while working. After discovering something reusable — a fact, constraint, decision, or expensive finding — it saves a named entry. Later contexts fetch entries on demand instead of re-deriving the work. The ledger persists across handoffs, context resets, and session restarts.
+A sparse pocket notebook the agent curates while working. After discovering something reusable — a fact, constraint, decision, or expensive finding — it writes a named page. Later contexts read pages on demand instead of re-deriving the work. The notebook persists across handoffs, context resets, and session restarts.
 
 ### Handoff — Deliberate Compaction
 
-When context degrades or the job changes, the agent saves reusable state to the ledger, writes a focused brief preserving what's still missing, and restarts clean. The new context starts with the brief front-and-center, all ledger entries accessible, and zero noise.
+When context degrades or the job changes, the agent saves reusable state to the notebook, writes a focused brief preserving what's still missing, and restarts clean. The new context starts with the brief front-and-center, all notebook pages accessible, and zero noise.
 
-**Rule of thumb:** The ledger holds reusable learned knowledge. Handoff carries the remaining situational context.
+**Rule of thumb:** The notebook holds reusable learned knowledge. Handoff carries the remaining situational context.
 
 ---
 
@@ -139,7 +139,7 @@ A single summary blob mixes durable knowledge with transient situational context
 | Operation | Primitive | What It Prevents |
 |-----------|-----------|-----------------|
 | **Isolate** | Spawn | Context pollution from noisy subtasks |
-| **Persist** | Ledger | Knowledge loss across resets and pivots |
+| **Persist** | Notebook | Knowledge loss across resets and pivots |
 | **Compact** | Handoff | Degradation from overstuffed context |
 
 ---
@@ -150,10 +150,10 @@ A single summary blob mixes durable knowledge with transient situational context
 |---|---|---|---|---|
 | **Compaction** | Runtime decides | User decides | Manual wipe + copy-paste | **Agent decides** |
 | **Subagents** | Pre-defined or manual trigger | None | None | **Agent spawns dynamically** |
-| **Persistent memory** | Background-generated (if at all) | None | None — gone on reset | **Ledger — agent-curated reusable continuity** |
+| **Persistent memory** | Background-generated (if at all) | None | None — gone on reset | **Notebook — agent-curated reusable continuity** |
 | **Context awareness** | Token count only | Token count only | None | **Primacy-zone heuristic (~30%)** |
-| **Cross-session continuity** | Rare (opt-in, background) | Manual copy-paste | Manual copy-paste | **Ledger persists across restarts** |
-| **Structured handoff** | No | No | No | **Yes — resets context while carrying forward non-ledger state explicitly** |
+| **Cross-session continuity** | Rare (opt-in, background) | Manual copy-paste | Manual copy-paste | **Notebook persists across restarts** |
+| **Structured handoff** | No | No | No | **Yes — resets context while carrying forward non-notebook state explicitly** |
 
 ---
 
@@ -166,10 +166,10 @@ The extension hooks into pi's lifecycle:
 
 | Hook | What it does |
 |------|-------------|
-| `before_agent_start` | Injects context management primer + live ledger listing into system prompt |
+| `before_agent_start` | Injects context management primer + live notebook index into system prompt |
 | `context` | Injects advisory watchdog reminders when context > 30% |
-| `session_start` | Rehydrates ledger from persisted entries; resets on `/new` |
-| `turn_end` | Updates TUI indicators (context %, ledger count) |
+| `session_start` | Rehydrates notebook pages from persisted entries; resets on `/new` |
+| `turn_end` | Updates TUI indicators (context %, notebook count) |
 | `agent_end` | Records last context usage percent |
 | `session_before_compact` | Consumes pending handoff task and sets it as compaction summary |
 
@@ -177,7 +177,7 @@ All state lives in a single `AgenticodingState` instance:
 
 ```typescript
 interface AgenticodingState {
-  ledger: Map<string, string>
+  notebookPages: Map<string, string>
   epoch: number
   lastContextPercent: number | null
   pendingHandoff: { task, source } | null
@@ -193,7 +193,7 @@ interface AgenticodingState {
 <details>
 <summary><strong>Deep dive → ARCHITECTURE.md</strong></summary>
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) for full module breakdown, tool schemas, lifecycle wiring, spawn child-session lifecycle, and ledger rehydration algorithm.
+See [ARCHITECTURE.md](ARCHITECTURE.md) for full module breakdown, tool schemas, lifecycle wiring, spawn child-session lifecycle, and notebook rehydration algorithm.
 
 </details>
 

--- a/agenticoding.test.ts
+++ b/agenticoding.test.ts
@@ -5,7 +5,7 @@ import { Text } from "@earendil-works/pi-tui";
 import { registerHandoffCommand } from "./handoff/command.js";
 import { registerHandoffTool } from "./handoff/tool.js";
 import { registerHandoffCompaction } from "./handoff/compact.js";
-import { registerWatchdog } from "./watchdog.js";
+import { buildNudge, registerWatchdog } from "./watchdog.js";
 import { createState, resetState } from "./state.js";
 import {
 	buildChildToolNames,
@@ -14,16 +14,19 @@ import {
 	registerSpawnTool,
 } from "./spawn/index.js";
 import { renderSpawnResult, flushSpawnFrameScheduler, resetSpawnFrameScheduler } from "./spawn/renderer.js";
-import { registerLedgerRehydration } from "./ledger/rehydration.js";
-import { saveLedgerEntry, resetLedgerWriteLock } from "./ledger/store.js";
-import { createLedgerToolDefinitions } from "./ledger/tools.js";
+import { registerNotebookRehydration } from "./notebook/rehydration.js";
+import { clearActiveNotebookTopic, setActiveNotebookTopic } from "./notebook/topic.js";
+import { registerNotebookTopicTool } from "./notebook/topic-tool.js";
+import { saveNotebookPage, resetNotebookWriteLock } from "./notebook/store.js";
+import { createNotebookToolDefinitions } from "./notebook/tools.js";
 import registerAgenticoding from "./index.js";
-import { STATUS_KEY_HANDOFF, WIDGET_KEY_WARNING, updateIndicators } from "./tui.js";
+import { CONTEXT_PRIMER } from "./system-prompt.js";
+import { STATUS_KEY_HANDOFF, STATUS_KEY_TOPIC, WIDGET_KEY_WARNING, updateIndicators } from "./tui.js";
 
 // Safety net: reset module-level mutable state after all tests.
 // Individual tests should also call reset*() at the start for explicit isolation.
 after(() => {
-	resetLedgerWriteLock();
+	resetNotebookWriteLock();
 	resetSpawnFrameScheduler();
 });
 
@@ -249,16 +252,26 @@ test("updateIndicators no-ops when ctx.hasUI is false", () => {
 	assert.equal(record.widgets.size, 0, "no-op should not call any setWidget");
 });
 
-test("updateIndicators shows ledger count in status", () => {
+test("updateIndicators shows notebook page count in status", () => {
 	const state = createState();
-	state.ledger.set("entry-1", "first entry");
-	state.ledger.set("entry-2", "second entry");
+	state.notebookPages.set("entry-1", "first entry");
+	state.notebookPages.set("entry-2", "second entry");
 	const record = { statuses: new Map<string, string | undefined>(), widgets: new Map<string, string[] | undefined>() };
 	const ctx = makeTUICtx({ percent: null, record });
 
 	updateIndicators(ctx, state);
-	const s = record.statuses.get("agenticoding-ledger");
-	assert.ok(s?.includes("2"), "ledger count should be 2");
+	const s = record.statuses.get("agenticoding-notebook");
+	assert.ok(s?.includes("2"), "notebook page count should be 2");
+});
+
+test("updateIndicators shows active notebook topic when set", () => {
+	const state = createState();
+	state.activeNotebookTopic = "oauth";
+	const record = { statuses: new Map<string, string | undefined>(), widgets: new Map<string, string[] | undefined>() };
+	const ctx = makeTUICtx({ percent: 30, record });
+
+	updateIndicators(ctx, state);
+	assert.equal(record.statuses.get(STATUS_KEY_TOPIC), "🧭 oauth");
 });
 
 test("updateIndicators hides widget below 70% context", () => {
@@ -293,7 +306,7 @@ test("/handoff sends the direction back through the LLM without opening the edit
 	assert.deepEqual(pi.sentUserMessages, [
 		{
 			content:
-				"Handoff direction: implement auth\n\nPrepare a real handoff in the current session and current context. Before calling the handoff tool, capture any reusable state in the ledger if needed. Then complete the picture in a concise but sufficiently detailed handoff brief and call the handoff tool in this turn. Preserve the important knowledge that is still only present in the current context so the next clean context can start well without re-deriving it. Use any structure that makes the next work unambiguous. Include findings, current state, unresolved questions, failed paths worth avoiding, next steps, refs, constraints, and spawn ideas when useful. Reference ledger entries by name when relevant.",
+				"Handoff direction: implement auth\n\nPrepare a handoff in the current session. First, save any durable reusable knowledge to the notebook: findings worth keeping, constraints discovered, decisions made, or other grounding future contexts will need. Then draft a concise but sufficiently detailed handoff brief capturing only the remaining situational context: current state, blockers, unresolved questions, failed paths worth avoiding, and next steps. The next context will read the notebook on demand, so do not duplicate notebook content in the brief. Use any structure that makes the next work unambiguous. Reference notebook pages by name when relevant.",
 			options: undefined,
 		},
 	]);
@@ -318,13 +331,14 @@ test("/handoff requires a direction", async () => {
 test("handoff tool triggers compaction and resumes with the compacted task", async () => {
 	const pi = new MockPi();
 	const state = createState();
+	state.notebookPages.set("auth-refresh", "sensitive notebook body");
 	state.pendingRequestedHandoff = { direction: "implement auth", enforcementAttempts: 0, toolCalled: false };
 	registerHandoffTool(pi as any, state);
 
 	let compactOptions: any;
 	const result = await pi.tools.get("handoff").execute(
 		"1",
-		{ task: "Goal: continue" },
+		{ task: "Goal: continue auth-refresh" },
 		undefined,
 		undefined,
 		{
@@ -336,7 +350,10 @@ test("handoff tool triggers compaction and resumes with the compacted task", asy
 
 	assert.equal(state.pendingHandoff?.source, "tool");
 	assert.match(state.pendingHandoff?.task ?? "", /## Handoff — Continue Previous Work/);
-	assert.match(state.pendingHandoff?.task ?? "", /Goal: continue/);
+	assert.match(state.pendingHandoff?.task ?? "", /Notebook pages hold durable grounding knowledge/);
+	assert.match(state.pendingHandoff?.task ?? "", /distilled next task and immediate situational context/);
+	assert.match(state.pendingHandoff?.task ?? "", /Goal: continue auth-refresh/);
+	assert.doesNotMatch(state.pendingHandoff?.task ?? "", /sensitive notebook body/);
 	assert.equal(state.pendingRequestedHandoff?.toolCalled, true);
 	assert.equal(typeof compactOptions?.onComplete, "function");
 	assert.equal(result.content[0].text, "Handoff started.");
@@ -351,6 +368,8 @@ test("handoff compaction replaces old context with the queued task", async () =>
 	const state = createState();
 	state.pendingHandoff = { task: "Goal: continue", source: "tool" };
 	state.pendingRequestedHandoff = { direction: "implement auth", enforcementAttempts: 1, toolCalled: true };
+	state.activeNotebookTopic = "oauth";
+	state.activeNotebookTopicSource = "human";
 	registerHandoffCompaction(pi as any, state);
 
 	const [handler] = pi.handlers.get("session_before_compact")!;
@@ -364,6 +383,8 @@ test("handoff compaction replaces old context with the queued task", async () =>
 
 	assert.equal(state.pendingHandoff, null);
 	assert.equal(state.pendingRequestedHandoff, null);
+	assert.equal(state.activeNotebookTopic, null);
+	assert.equal(state.activeNotebookTopicSource, null);
 	assert.equal(result.compaction.summary, "Goal: continue");
 	assert.equal(result.compaction.tokensBefore, 123);
 	assert.equal(result.compaction.firstKeptEntryId, "leaf-1-handoff-cut");
@@ -507,6 +528,7 @@ test("context injects watchdog reminder before each LLM call", async () => {
 	const pi = new MockPi();
 	registerAgenticoding(pi as any);
 	const [handler] = pi.handlers.get("context")!;
+	await pi.commands.get("notebook")!.handler("oauth", { hasUI: false, getContextUsage: () => null });
 
 	const result = await handler(
 		{ messages: [{ role: "user", content: "hi", timestamp: 1 }] },
@@ -521,6 +543,25 @@ test("context injects watchdog reminder before each LLM call", async () => {
 	assert.equal(result.messages[1].customType, "agenticoding-watchdog");
 	assert.equal(result.messages[1].display, false);
 	assert.match(result.messages[1].content, /Context at 70%/);
+	assert.match(result.messages[1].content, /Active notebook topic: oauth/);
+	assert.match(result.messages[1].content, /spawn it instead of polluting the parent context/i);
+	assert.doesNotMatch(result.messages[1].content, /If you're mid-job and still clear|consider a handoff and draft a clear brief for what comes next/i);
+});
+
+test("context injects a boundary nudge below 30% after an explicit topic change", async () => {
+	const pi = new MockPi();
+	registerAgenticoding(pi as any);
+	const [handler] = pi.handlers.get("context")!;
+	await pi.commands.get("notebook")!.handler("oauth", { hasUI: false, getContextUsage: () => null });
+	await pi.commands.get("notebook")!.handler("billing", { hasUI: false, getContextUsage: () => null });
+
+	const result = await handler(
+		{ messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+		{ getContextUsage: () => ({ percent: 20 }) },
+	);
+
+	assert.equal(result.messages[1].display, false);
+	assert.match(result.messages[1].content, /Notebook topic changed from oauth to billing/);
 });
 
 test("watchdog stays advisory when a requested handoff is not completed", async () => {
@@ -825,11 +866,11 @@ test("spawn execute propagates only executable parent tools to child session", a
 	assert.equal(seenConfig.tools.includes("spawn"), false);
 });
 
-test("spawn execute builds prompt with ledger and task", async () => {
+test("spawn execute builds prompt with notebook pages and task", async () => {
 	const pi = new MockPi();
 	pi.setActiveTools(["read", "bash", "spawn"]);
 	const state = createState();
-	state.ledger.set("entry-a", "preview line\nfull body");
+	state.notebookPages.set("entry-a", "preview line\nfull body");
 
 	let seenPrompt = "";
 	const mockFactory = async (config: any) => {
@@ -855,7 +896,7 @@ test("spawn execute builds prompt with ledger and task", async () => {
 		{ model: { id: "mock-model" }, cwd: "/tmp" },
 	);
 
-	// Verify user-facing invariants: task text is included, ledger entries are referenced
+	// Verify user-facing invariants: task text is included, notebook pages are referenced
 	assert.match(seenPrompt, /Do the task/);
 	assert.match(seenPrompt, /entry-a: preview line/);
 });
@@ -1279,9 +1320,9 @@ test("child tool names inherit builtin parent tools, exclude handoff and spawn",
 	assert.ok(toolNames.includes("read"));
 	assert.ok(toolNames.includes("bash"));
 	assert.equal(toolNames.includes("future_tool"), false);
-	assert.ok(toolNames.includes("ledger_add"));
-	assert.ok(toolNames.includes("ledger_get"));
-	assert.ok(toolNames.includes("ledger_list"));
+	assert.ok(toolNames.includes("notebook_write"));
+	assert.ok(toolNames.includes("notebook_read"));
+	assert.ok(toolNames.includes("notebook_index"));
 	assert.equal(toolNames.includes("handoff"), false);
 	assert.equal(toolNames.includes("spawn"), false);
 });
@@ -1567,7 +1608,7 @@ test("spawn execute truncates child output by byte limit", async () => {
 	assert.equal(result.content[0].text.includes("\n"), true);
 });
 
-test("spawn execute tells children when no ledger entries exist", async () => {
+test("spawn execute tells children when no notebook pages exist", async () => {
 	const pi = new MockPi();
 	pi.setActiveTools(["read", "bash", "spawn"]);
 	const state = createState();
@@ -1595,8 +1636,10 @@ test("spawn execute tells children when no ledger entries exist", async () => {
 		{ model: { id: "mock-model" }, cwd: "/tmp" },
 	);
 
-	assert.match(promptText, /No ledger entries\./);
-	assert.doesNotMatch(promptText, /Available ledger entries:/);
+	assert.match(promptText, /No notebook pages\./);
+	assert.doesNotMatch(promptText, /Available notebook pages:/);
+	assert.match(promptText, /store only durable grounding knowledge for future contexts/i);
+	assert.match(promptText, /Keep transient task state in your final reply to the parent\./);
 });
 
 test("executeSpawn → onUpdate → renderResult chains session ownership", async () => {
@@ -1764,10 +1807,10 @@ test("spawn renderCall shows prompt preview and thinking level", () => {
 
 
 
-test("ledger rehydration rebuilds the latest epoch and enables ledger tools", async () => {
+test("notebook rehydration rebuilds the latest epoch and enables notebook tools", async () => {
 	const pi = new MockPi();
 	const state = createState();
-	registerLedgerRehydration(pi as any, state);
+	registerNotebookRehydration(pi as any, state);
 	const [handler] = pi.handlers.get("session_start")!;
 
 	await handler(
@@ -1776,112 +1819,140 @@ test("ledger rehydration rebuilds the latest epoch and enables ledger tools", as
 			sessionManager: {
 				getBranch: () => [
 					{ type: "custom", customType: "ledger-entry", data: { epoch: 1, name: "old", content: "old" } },
-					{ type: "custom", customType: "ledger-entry", data: { epoch: 2, name: "keep", content: "new" } },
-					{ type: "custom", customType: "ledger-entry", data: { epoch: 2, name: "keep", content: "newer" } },
+					{ type: "custom", customType: "notebook-entry", data: { epoch: 2, name: "keep", content: "new" } },
+					{ type: "custom", customType: "notebook-entry", data: { epoch: 2, name: "keep", content: "newer" } },
 				],
 			},
 		},
 	);
 
 	assert.equal(state.epoch, 2);
-	assert.deepEqual(Array.from(state.ledger.entries()), [["keep", "newer"]]);
-	assert.deepEqual(pi.activeTools, ["ledger_get", "ledger_list"]);
+	assert.deepEqual(Array.from(state.notebookPages.entries()), [["keep", "newer"]]);
+	assert.deepEqual(pi.activeTools, ["notebook_read", "notebook_index"]);
 });
 
-test("ledger tools add/get/list return stable contract details", async () => {
+
+test("notebook rehydration respects a preset epoch and avoids duplicate active tools", async () => {
+	const pi = new MockPi();
+	pi.activeTools = ["read", "notebook_read", "notebook_index"];
+	const state = createState();
+	state.epoch = 7;
+	registerNotebookRehydration(pi as any, state);
+	const [handler] = pi.handlers.get("session_start")!;
+
+	await handler(
+		{},
+		{
+			sessionManager: {
+				getBranch: () => [
+					{ type: "custom", customType: "notebook-entry", data: { epoch: 6, name: "stale", content: "old" } },
+					{ type: "custom", customType: "notebook-entry", data: { epoch: 7, name: "keep", content: "fresh" } },
+					{ type: "custom", customType: "notebook-entry", data: { epoch: 8, name: "future", content: "skip" } },
+				],
+			},
+		},
+	);
+
+	assert.equal(state.epoch, 7);
+	assert.deepEqual(Array.from(state.notebookPages.entries()), [["keep", "fresh"]]);
+	assert.deepEqual(pi.activeTools, ["read", "notebook_read", "notebook_index"]);
+});
+
+test("notebook tools add/get/list return stable contract details", async () => {
 	const pi = new MockPi();
 	const state = createState();
-	const [ledgerAdd, ledgerGet, ledgerList] = createLedgerToolDefinitions(pi as any, state);
+	const [notebookWrite, notebookRead, notebookIndex] = createNotebookToolDefinitions(pi as any, state);
 
-	const addResult = await ledgerAdd.execute("1", { name: "entry-a", content: "first line\nsecond line" }, undefined, undefined, {} as any);
+	const addResult = await notebookWrite.execute("1", { name: "entry-a", content: "first line\nsecond line" }, undefined, undefined, {} as any);
 	assert.deepEqual(addResult.details, { entries: ["entry-a"], preview: "first line" });
-	assert.equal(state.ledger.get("entry-a"), "first line\nsecond line");
+	assert.equal(state.notebookPages.get("entry-a"), "first line\nsecond line");
 	assert.equal(pi.appendedEntries.length, 1);
-	assert.equal(pi.appendedEntries[0].customType, "ledger-entry");
+	assert.equal(pi.appendedEntries[0].customType, "notebook-entry");
 	assert.equal(pi.appendedEntries[0].data.name, "entry-a");
 
-	const getResult = await ledgerGet.execute("2", { name: "entry-a" }, undefined, undefined, {} as any);
+	const getResult = await notebookRead.execute("2", { name: "entry-a" }, undefined, undefined, {} as any);
 	assert.equal(getResult.details.found, true);
 	assert.deepEqual(getResult.details.entries, ["entry-a"]);
 	assert.match(getResult.content[0].text, /--- entry-a ---/);
 	assert.match(getResult.content[0].text, /second line/);
 
-	const listResult = await ledgerList.execute("3", {}, undefined, undefined, {} as any);
+	const listResult = await notebookIndex.execute("3", {}, undefined, undefined, {} as any);
 	assert.deepEqual(listResult.details, { entries: ["entry-a"] });
 	assert.match(listResult.content[0].text, /entry-a: first line/);
 });
 
-test("child ledger tools reject stale access after reset", async () => {
+test("child notebook tools reject stale access after reset", async () => {
 	const pi = new MockPi();
 	const state = createState();
-	state.ledger.set("entry-a", "alpha");
+	state.notebookPages.set("entry-a", "alpha");
 	let stale = false;
-	const [ledgerAdd, ledgerGet, ledgerList] = createLedgerToolDefinitions(pi as any, state, { isStale: () => stale });
+	const [notebookWrite, notebookRead, notebookIndex] = createNotebookToolDefinitions(pi as any, state, { isStale: () => stale });
 
 	stale = true;
 	await assert.rejects(
-		() => ledgerAdd.execute("1", { name: "entry-a", content: "alpha" }, undefined, undefined, {} as any),
+		() => notebookWrite.execute("1", { name: "entry-a", content: "alpha" }, undefined, undefined, {} as any),
 		/invalidated by reset/i,
 	);
 	await assert.rejects(
-		() => ledgerGet.execute("2", { name: "entry-a" }, undefined, undefined, {} as any),
+		() => notebookRead.execute("2", { name: "entry-a" }, undefined, undefined, {} as any),
 		/invalidated by reset/i,
 	);
 	await assert.rejects(
-		() => ledgerList.execute("3", {}, undefined, undefined, {} as any),
+		() => notebookIndex.execute("3", {}, undefined, undefined, {} as any),
 		/invalidated by reset/i,
 	);
-	assert.equal(state.ledger.get("entry-a"), "alpha");
+	assert.equal(state.notebookPages.get("entry-a"), "alpha");
 	assert.equal(pi.appendedEntries.length, 0);
 });
 
-test("child ledger_add succeeds while child session is fresh", async () => {
+test("child notebook_write succeeds while child session is fresh", async () => {
 	const pi = new MockPi();
 	const state = createState();
-	const [ledgerAdd] = createLedgerToolDefinitions(pi as any, state, { isStale: () => false });
+	const [notebookWrite] = createNotebookToolDefinitions(pi as any, state, { isStale: () => false });
 
-	const result = await ledgerAdd.execute("1", { name: "entry-a", content: "alpha" }, undefined, undefined, {} as any);
+	const result = await notebookWrite.execute("1", { name: "entry-a", content: "alpha" }, undefined, undefined, {} as any);
 	assert.deepEqual(result.details, { entries: ["entry-a"], preview: "alpha" });
-	assert.equal(state.ledger.get("entry-a"), "alpha");
+	assert.equal(state.notebookPages.get("entry-a"), "alpha");
 	assert.equal(pi.appendedEntries.length, 1);
 });
 
-test("ledger_get reports not found with current entry names", async () => {
+test("notebook_read reports not found with current page names", async () => {
 	const pi = new MockPi();
 	const state = createState();
-	state.ledger.set("entry-a", "alpha");
-	state.ledger.set("entry-b", "beta");
-	const [, ledgerGet] = createLedgerToolDefinitions(pi as any, state);
+	state.notebookPages.set("entry-a", "alpha");
+	state.notebookPages.set("entry-b", "beta");
+	const [, notebookRead] = createNotebookToolDefinitions(pi as any, state);
 
-	const result = await ledgerGet.execute("1", { name: "missing" }, undefined, undefined, {} as any);
+	const result = await notebookRead.execute("1", { name: "missing" }, undefined, undefined, {} as any);
 	assert.deepEqual(result.details, { entries: ["entry-a", "entry-b"], found: false });
-	assert.match(result.content[0].text, /Entry "missing" not found\./);
+	assert.match(result.content[0].text, /Notebook page "missing" not found\./);
+	assert.match(result.content[0].text, /Notebook Pages:\n/);
 	assert.match(result.content[0].text, /entry-a: alpha/);
 	assert.match(result.content[0].text, /entry-b: beta/);
 });
 
-test("ledger tools show empty-state placeholders", async () => {
+test("notebook tools show empty-state placeholders", async () => {
 	const pi = new MockPi();
 	const state = createState();
-	const [, ledgerGet, ledgerList] = createLedgerToolDefinitions(pi as any, state);
+	const [, notebookRead, notebookIndex] = createNotebookToolDefinitions(pi as any, state);
 
-	const missing = await ledgerGet.execute("1", { name: "missing" }, undefined, undefined, {} as any);
+	const missing = await notebookRead.execute("1", { name: "missing" }, undefined, undefined, {} as any);
 	assert.deepEqual(missing.details, { entries: [], found: false });
-	assert.match(missing.content[0].text, /Entries:\n\(empty\)/);
+	assert.match(missing.content[0].text, /Notebook Pages:\n\(empty\)/);
 
-	const list = await ledgerList.execute("2", {}, undefined, undefined, {} as any);
+	const list = await notebookIndex.execute("2", {}, undefined, undefined, {} as any);
 	assert.deepEqual(list.details, { entries: [] });
-	assert.match(list.content[0].text, /Entries:\n\(empty\)/);
+	assert.match(list.content[0].text, /Notebook Pages:\n\(empty\)/);
 });
 
-test("ledger_add pushes onUpdate and refreshes UI indicators", async () => {
+test("notebook_write pushes onUpdate and refreshes UI indicators", async () => {
 	const pi = new MockPi();
 	const state = createState();
-	const [ledgerAdd] = createLedgerToolDefinitions(pi as any, state);
+	const [notebookWrite] = createNotebookToolDefinitions(pi as any, state);
 	const record = { statuses: new Map<string, string | undefined>(), widgets: new Map<string, string[] | undefined>() };
 	let update: any;
 
-	const result = await ledgerAdd.execute(
+	const result = await notebookWrite.execute(
 		"1",
 		{ name: "entry-a", content: "first line\nsecond line" },
 		undefined,
@@ -1891,19 +1962,19 @@ test("ledger_add pushes onUpdate and refreshes UI indicators", async () => {
 
 	assert.equal(update.content[0].text, 'Saved "entry-a": first line');
 	assert.deepEqual(update.details, { entries: ["entry-a"], preview: "first line" });
-	assert.equal(record.statuses.get("agenticoding-ledger"), "📒 1");
+	assert.equal(record.statuses.get("agenticoding-notebook"), "📒 1");
 	assert.deepEqual(result.details, { entries: ["entry-a"], preview: "first line" });
 });
 
-test("ledger tool renderers expose stable call/result summaries", async () => {
+test("notebook tool renderers expose stable call/result summaries", async () => {
 	const pi = new MockPi();
 	const state = createState();
-	const [ledgerAdd, ledgerGet, ledgerList] = createLedgerToolDefinitions(pi as any, state);
+	const [notebookWrite, notebookRead, notebookIndex] = createNotebookToolDefinitions(pi as any, state);
 
-	const addCall = ledgerAdd.renderCall!({ name: "entry-a", content: "first line\nsecond line" }, theme, {} as any) as Text;
-	assert.match(stripAnsi(addCall.render(120).join("\n")), /ledger_add "entry-a": first line/);
+	const addCall = notebookWrite.renderCall!({ name: "entry-a", content: "first line\nsecond line" }, theme, {} as any) as Text;
+	assert.match(stripAnsi(addCall.render(120).join("\n")), /notebook_write "entry-a": first line/);
 
-	const addResult = ledgerAdd.renderResult!(
+	const addResult = notebookWrite.renderResult!(
 		{ content: [{ type: "text", text: "" }], details: { entries: ["entry-a"], preview: "first line" } },
 		{ expanded: true },
 		theme,
@@ -1912,7 +1983,7 @@ test("ledger tool renderers expose stable call/result summaries", async () => {
 	assert.match(stripAnsi(addResult.render(120).join("\n")), /Saved "entry-a": first line/);
 	assert.match(stripAnsi(addResult.render(120).join("\n")), /entry-a/);
 
-	const getResult = ledgerGet.renderResult!(
+	const getResult = notebookRead.renderResult!(
 		{ content: [{ type: "text", text: "ignored" }], details: { entries: ["entry-a"], found: true, body: "body" } },
 		{ expanded: true },
 		theme,
@@ -1921,7 +1992,7 @@ test("ledger tool renderers expose stable call/result summaries", async () => {
 	assert.match(stripAnsi(getResult.render(120).join("\n")), /"entry-a"/);
 	assert.match(stripAnsi(getResult.render(120).join("\n")), /body/);
 
-	const getResultWithDelimiters = ledgerGet.renderResult!(
+	const getResultWithDelimiters = notebookRead.renderResult!(
 		{ content: [{ type: "text", text: "ignored" }], details: { entries: ["entry-a"], found: true, body: "line 1\n---\nline 2" } },
 		{ expanded: true },
 		theme,
@@ -1930,31 +2001,31 @@ test("ledger tool renderers expose stable call/result summaries", async () => {
 	assert.match(stripAnsi(getResultWithDelimiters.render(120).join("\n")), /line 1/);
 	assert.match(stripAnsi(getResultWithDelimiters.render(120).join("\n")), /line 2/);
 
-	const listResult = ledgerList.renderResult!(
+	const listResult = notebookIndex.renderResult!(
 		{ content: [{ type: "text", text: "" }], details: { entries: ["entry-a", "entry-b"] } },
 		{ expanded: true },
 		theme,
 		{} as any,
 	) as Text;
-	assert.match(stripAnsi(listResult.render(120).join("\n")), /2 entries/);
+	assert.match(stripAnsi(listResult.render(120).join("\n")), /2 pages/);
 	assert.match(stripAnsi(listResult.render(120).join("\n")), /entry-a/);
 	assert.match(stripAnsi(listResult.render(120).join("\n")), /entry-b/);
 });
 
-test("/ledger exits cleanly when headless", async () => {
+test("/notebook exits cleanly when headless", async () => {
 	const pi = new MockPi();
 	registerAgenticoding(pi as any);
 
-	await assert.doesNotReject(() => pi.commands.get("ledger")!.handler("", { hasUI: false }));
+	await assert.doesNotReject(() => pi.commands.get("notebook")!.handler("", { hasUI: false }));
 });
 
-test("/ledger empty overlay renders empty state and closes on input", async () => {
+test("/notebook empty overlay renders empty state and closes on input", async () => {
 	const pi = new MockPi();
 	registerAgenticoding(pi as any);
 	let overlay: any;
 	let doneCalls = 0;
 
-	await pi.commands.get("ledger")!.handler("", {
+	await pi.commands.get("notebook")!.handler("", {
 		hasUI: true,
 		ui: {
 			theme,
@@ -1965,22 +2036,22 @@ test("/ledger empty overlay renders empty state and closes on input", async () =
 	});
 
 	const lines = stripAnsi(overlay.render(120).join("\n"));
-	assert.match(lines, /Ledger \(0 entries\)/);
-	assert.match(lines, /\(empty\) — use ledger_add to create entries/);
+	assert.match(lines, /Notebook \(0 pages\)/);
+	assert.match(lines, /\(empty\) — use notebook_write to create pages/);
 	overlay.handleInput("x");
 	assert.equal(doneCalls, 1);
 });
 
-test("/ledger selection previews the chosen entry", async () => {
+test("/notebook selection previews the chosen entry", async () => {
 	const pi = new MockPi();
 	registerAgenticoding(pi as any);
 	const notifications: string[] = [];
-	const ledgerAdd = pi.tools.get("ledger_add");
-	await ledgerAdd.execute("1", { name: "alpha", content: "body line\nsecond line" }, undefined, undefined, makeTUICtx());
+	const notebookWrite = pi.tools.get("notebook_write");
+	await notebookWrite.execute("1", { name: "alpha", content: "body line\nsecond line" }, undefined, undefined, makeTUICtx());
 	let overlay: any;
 	let doneCalls = 0;
 
-	await pi.commands.get("ledger")!.handler("", {
+	await pi.commands.get("notebook")!.handler("", {
 		hasUI: true,
 		ui: {
 			theme,
@@ -2003,15 +2074,15 @@ test("/ledger selection previews the chosen entry", async () => {
 	assert.equal(doneCalls, 1);
 });
 
-test("/ledger overlay sorts entries consistently", async () => {
+test("/notebook overlay sorts entries consistently", async () => {
 	const pi = new MockPi();
 	registerAgenticoding(pi as any);
-	const ledgerAdd = pi.tools.get("ledger_add");
-	await ledgerAdd.execute("1", { name: "zeta", content: "last" }, undefined, undefined, makeTUICtx());
-	await ledgerAdd.execute("2", { name: "alpha", content: "first" }, undefined, undefined, makeTUICtx());
+	const notebookWrite = pi.tools.get("notebook_write");
+	await notebookWrite.execute("1", { name: "zeta", content: "last" }, undefined, undefined, makeTUICtx());
+	await notebookWrite.execute("2", { name: "alpha", content: "first" }, undefined, undefined, makeTUICtx());
 	let overlay: any;
 
-	await pi.commands.get("ledger")!.handler("", {
+	await pi.commands.get("notebook")!.handler("", {
 		hasUI: true,
 		ui: {
 			theme,
@@ -2026,19 +2097,19 @@ test("/ledger overlay sorts entries consistently", async () => {
 	assert.ok(lines.indexOf("alpha") < lines.indexOf("zeta"), lines);
 });
 
-test("saveLedgerEntry serializes concurrent writes and preserves completion order", async () => {
-	resetLedgerWriteLock();
+test("saveNotebookPage serializes concurrent writes and preserves completion order", async () => {
+	resetNotebookWriteLock();
 	const pi = new MockPi();
 	const state = createState();
 	const firstGate = createDeferred();
 	const order: string[] = [];
 
-	const first = saveLedgerEntry(pi as any, state, "entry-a", "first", async () => {
+	const first = saveNotebookPage(pi as any, state, "entry-a", "first", async () => {
 		order.push("first:start");
 		await firstGate.promise;
 		order.push("first:end");
 	});
-	const second = saveLedgerEntry(pi as any, state, "entry-a", "second", async () => {
+	const second = saveNotebookPage(pi as any, state, "entry-a", "second", async () => {
 		order.push("second:start");
 	});
 
@@ -2048,57 +2119,74 @@ test("saveLedgerEntry serializes concurrent writes and preserves completion orde
 	await Promise.all([first, second]);
 
 	assert.deepEqual(order, ["first:start", "first:end", "second:start"]);
-	assert.equal(state.ledger.get("entry-a"), "second");
+	assert.equal(state.notebookPages.get("entry-a"), "second");
 	assert.deepEqual(pi.appendedEntries.map((entry) => entry.data.content), ["first", "second"]);
-	resetLedgerWriteLock();
+	resetNotebookWriteLock();
 });
 
-test("saveLedgerEntry rejects true reentrancy explicitly", async () => {
-	resetLedgerWriteLock();
+test("saveNotebookPage rejects true reentrancy explicitly", async () => {
+	resetNotebookWriteLock();
 	const pi = new MockPi();
 	const state = createState();
 
 	await assert.rejects(
-		() => saveLedgerEntry(pi as any, state, "outer", "outer", async () => {
-			await saveLedgerEntry(pi as any, state, "inner", "inner");
+		() => saveNotebookPage(pi as any, state, "outer", "outer", async () => {
+			await saveNotebookPage(pi as any, state, "inner", "inner");
 		}),
 		/not reentrant/i,
 	);
-	assert.equal(state.ledger.size, 0);
-	resetLedgerWriteLock();
+	assert.equal(state.notebookPages.size, 0);
+	resetNotebookWriteLock();
 });
 
-test("saveLedgerEntry releases the lock when assertWritable throws", async () => {
-	resetLedgerWriteLock();
+test("saveNotebookPage releases the lock when assertWritable throws", async () => {
+	resetNotebookWriteLock();
 	const pi = new MockPi();
 	const state = createState();
 
 	await assert.rejects(
-		() => saveLedgerEntry(pi as any, state, "broken", "value", async () => {
+		() => saveNotebookPage(pi as any, state, "broken", "value", async () => {
 			throw new Error("blocked");
 		}),
 		/blocked/,
 	);
-	await assert.doesNotReject(() => saveLedgerEntry(pi as any, state, "fresh", "value"));
-	assert.equal(state.ledger.get("fresh"), "value");
-	resetLedgerWriteLock();
+	await assert.doesNotReject(() => saveNotebookPage(pi as any, state, "fresh", "value"));
+	assert.equal(state.notebookPages.get("fresh"), "value");
+	resetNotebookWriteLock();
 });
 
-test("resetLedgerWriteLock clears abandoned lock state for later writes", async () => {
-	resetLedgerWriteLock();
+test("resetNotebookWriteLock clears abandoned lock state for later writes", async () => {
+	resetNotebookWriteLock();
 	const pi = new MockPi();
 	const state = createState();
 	const gate = createDeferred();
-	void saveLedgerEntry(pi as any, state, "stuck", "value", async () => {
+	void saveNotebookPage(pi as any, state, "stuck", "value", async () => {
 		await gate.promise;
 	});
 	await Promise.resolve();
-	resetLedgerWriteLock();
+	resetNotebookWriteLock();
 
-	await assert.doesNotReject(() => saveLedgerEntry(pi as any, state, "fresh", "value"));
-	assert.equal(state.ledger.get("fresh"), "value");
+	await assert.doesNotReject(() => saveNotebookPage(pi as any, state, "fresh", "value"));
+	assert.equal(state.notebookPages.get("fresh"), "value");
 	gate.resolve();
-	resetLedgerWriteLock();
+	resetNotebookWriteLock();
+});
+
+
+test("saveNotebookPage truncates oversized content before persisting", async () => {
+	resetNotebookWriteLock();
+	const pi = new MockPi();
+	const state = createState();
+	const content = "first line\n" + "detail\n".repeat(3000);
+
+	const result = await saveNotebookPage(pi as any, state, "large-page", content);
+	const persisted = pi.appendedEntries[0].data.content;
+
+	assert.ok(persisted.length < content.length, "oversized notebook content should be truncated");
+	assert.equal(state.notebookPages.get("large-page"), persisted);
+	assert.equal(result.preview, "first line");
+	assert.match(persisted, /^first line/m);
+	resetNotebookWriteLock();
 });
 
 test("nested spawn invalidate rebuilds from the attached session transcript", () => {
@@ -2911,29 +2999,155 @@ test("nested spawn render cache preserves stable output for identical params", (
 	assert.ok(wide.some((l: string) => l.includes("hello") || l.includes("m • low")));
 });
 
-test("ledger tool definitions include prompt hints when withPromptHints is true", () => {
+test("notebook tool definitions include prompt hints when withPromptHints is true", () => {
 	const pi = new MockPi();
 	const state = createState();
-	const tools = createLedgerToolDefinitions(pi as any, state, { withPromptHints: true });
+	const tools = createNotebookToolDefinitions(pi as any, state, { withPromptHints: true });
 
 	for (const tool of tools) {
 		assert.ok(typeof tool.promptSnippet === "string", `${tool.name} should have promptSnippet when withPromptHints=true`);
+		assert.ok(Array.isArray(tool.promptGuidelines), `${tool.name} should have promptGuidelines when withPromptHints=true`);
 	}
-	const ledgerAdd = tools.find(t => t.name === "ledger_add")!;
-	assert.ok(Array.isArray(ledgerAdd.promptGuidelines), "ledger_add should have promptGuidelines array");
-	assert.ok(ledgerAdd.promptGuidelines!.length > 0, "ledger_add promptGuidelines should not be empty");
+	const notebookWrite = tools.find(t => t.name === "notebook_write")!;
+	const notebookRead = tools.find(t => t.name === "notebook_read")!;
+	const notebookIndex = tools.find(t => t.name === "notebook_index")!;
+
+	// Structural invariants: all guidelines exist and are non-trivial
+	for (const tool of tools) {
+		assert.ok(tool.promptGuidelines!.length >= 2, `${tool.name} should have at least 2 promptGuidelines`);
+		assert.ok(tool.promptGuidelines!.every((g: string) => g.length > 10), `${tool.name} each guideline should be non-trivial`);
+	}
+
+	// Conceptual: notebook_write is future-context oriented
+	const writeGuidelines = notebookWrite.promptGuidelines!.join(" ");
+	assert.match(writeGuidelines, /subject-oriented pages/i);
+	assert.match(writeGuidelines, /fresh context/i);
+	assert.match(writeGuidelines, /belongs in handoff/i);
+
+	// Conceptual: descriptions mention the notebook-page metaphor
+	assert.match(notebookWrite.description, /page|future contexts/i);
+	assert.match(notebookRead.description, /notebook page|page/i);
+	assert.match(notebookIndex.description, /notebook index|index/i);
 });
 
-test("ledger tool definitions omit prompt hints by default", () => {
+test("topic helpers manage the active notebook topic lifecycle", () => {
+	const state = createState();
+	const first = setActiveNotebookTopic(state, "OAuth", "agent");
+	assert.deepEqual(first, {
+		changed: true,
+		previous: null,
+		current: "oauth",
+		boundaryHint: null,
+	});
+	const second = setActiveNotebookTopic(state, "Billing", "human");
+	assert.equal(second.boundaryHint?.from, "oauth");
+	assert.equal(second.boundaryHint?.to, "billing");
+	clearActiveNotebookTopic(state);
+	assert.equal(state.activeNotebookTopic, null);
+	assert.equal(state.activeNotebookTopicSource, null);
+	assert.equal(state.pendingTopicBoundaryHint, null);
+});
+
+test("notebook_topic_set establishes a fresh topic and refuses overrides", async () => {
 	const pi = new MockPi();
 	const state = createState();
-	const tools = createLedgerToolDefinitions(pi as any, state);
+	registerNotebookTopicTool(pi as any, state);
+
+	const tool = pi.tools.get("notebook_topic_set");
+	const first = await tool.execute("1", { topic: "OAuth" });
+	assert.equal(first.details.topic, "oauth");
+	assert.equal(state.activeNotebookTopic, "oauth");
+	assert.equal(state.activeNotebookTopicSource, "agent");
+
+	await assert.rejects(() => tool.execute("2", { topic: "billing" }), /already exists/);
+});
+
+test("buildNudge no longer emits the old percent-only handoff text", () => {
+	const old = buildNudge({ activeNotebookTopic: "oauth", pendingTopicBoundaryHint: null }, 46);
+	assert.doesNotMatch(old, /One context, one job\.|If you're mid-job and still clear|consider a handoff and draft a clear brief/i);
+	assert.match(old, /Active notebook topic: oauth/);
+	assert.match(old, /prefer spawn/i);
+});
+
+test("CONTEXT_PRIMER frames the notebook as durable grounding and handoff as direction", () => {
+	// No stale "ledger" references
+	assert.doesNotMatch(CONTEXT_PRIMER, /ledger/i,
+		"CONTEXT_PRIMER should contain zero stale ledger references after the rename");
+
+	// Structural: section headers exist
+	// Structural: section headers exist
+	assert.match(CONTEXT_PRIMER, /### Notebook/);
+	assert.match(CONTEXT_PRIMER, /### Active notebook topic/);
+	assert.match(CONTEXT_PRIMER, /### Handoff/);
+	assert.match(CONTEXT_PRIMER, /### Rules/);
+
+	// Structural: Rules section names the tools it references
+	const rules = CONTEXT_PRIMER.split("### Rules")[1];
+	assert.ok(rules.includes("notebook_index"), "Rules should mention notebook_index");
+	assert.ok(rules.includes("notebook_read"), "Rules should mention notebook_read");
+	assert.ok(rules.includes("distilled next task"), "Rules should frame handoff as the next task");
+
+	// Conceptual: Notebook section contains durable grounding concepts
+	const notebookSection = CONTEXT_PRIMER.split("### Notebook")[1].split("### Active notebook topic")[0].toLowerCase();
+	for (const concept of ["future contexts", "subject", "architecture", "constraints", "verified facts"]) {
+		assert.ok(notebookSection.includes(concept), `Notebook section should mention "${concept}"`);
+		}
+
+	const topicSection = CONTEXT_PRIMER.split("### Active notebook topic")[1].split("### Handoff")[0].toLowerCase();
+	assert.ok(topicSection.includes("semantic frame"), "Topic section should mention semantic frame");
+	assert.ok(topicSection.includes("prefer spawn"), "Topic section should bias spawn inside a topic");
+	assert.ok(topicSection.includes("prefer handoff"), "Topic section should bias handoff across topics");
+
+	const handoffSection = CONTEXT_PRIMER.split("### Handoff")[1].split("### Rules")[0].toLowerCase();
+	assert.ok(handoffSection.includes("situational context"), "Handoff should mention situational context");
+	assert.ok(handoffSection.includes("do not duplicate"), "Handoff should avoid duplicating notebook content");
+});
+
+test("before_agent_start injects the notebook primer and live notebook pages", async () => {
+	const pi = new MockPi();
+	registerAgenticoding(pi as any);
+	await pi.commands.get("notebook")!.handler("oauth", { hasUI: false, getContextUsage: () => null });
+	const notebookWrite = pi.tools.get("notebook_write");
+	await notebookWrite.execute("1", { name: "alpha", content: "first line\nsecond line" }, undefined, undefined, makeTUICtx());
+
+	const [handler] = pi.handlers.get("before_agent_start")!;
+	const result = await handler({ systemPrompt: "Base system prompt." }, makeTUICtx({ hasUI: false }));
+
+	assert.match(result.systemPrompt, /Base system prompt\./);
+	assert.match(result.systemPrompt, /## Context management/);
+	assert.match(result.systemPrompt, /## Active Notebook Topic/);
+	assert.match(result.systemPrompt, /Current topic: `oauth`/);
+	assert.match(result.systemPrompt, /## Active Notebook Pages/);
+	assert.match(result.systemPrompt, /The following pages are available via notebook_read by name:/);
+	assert.ok(result.systemPrompt.includes("Reference pages by name"), "should reference pages by name");
+	assert.match(result.systemPrompt, /alpha: first line/);
+	assert.ok(result.systemPrompt.includes(CONTEXT_PRIMER), "system prompt should include CONTEXT_PRIMER verbatim");
+});
+
+test("notebook tool definitions omit prompt hints by default", () => {
+	const pi = new MockPi();
+	const state = createState();
+	const tools = createNotebookToolDefinitions(pi as any, state);
 
 	for (const tool of tools) {
 		assert.equal(tool.promptSnippet, undefined, `${tool.name} should not have promptSnippet by default`);
+		assert.equal(tool.promptGuidelines, undefined, `${tool.name} should not have promptGuidelines by default`);
 	}
-	const ledgerAdd = tools.find(t => t.name === "ledger_add")!;
-	assert.equal(ledgerAdd.promptGuidelines, undefined, "ledger_add should not have promptGuidelines by default");
+});
+
+test("spawn tool definitions include prompt hints when registered", () => {
+	const pi = new MockPi();
+	const state = createState();
+	registerSpawnTool(pi as any, state);
+
+	const spawnTool = pi.tools.get("spawn")!;
+	assert.ok(typeof spawnTool.promptSnippet === "string", "spawn should have promptSnippet");
+	assert.ok(spawnTool.promptSnippet!.length > 10, "spawn promptSnippet should be non-trivial");
+	assert.ok(Array.isArray(spawnTool.promptGuidelines), "spawn should have promptGuidelines");
+	assert.ok(spawnTool.promptGuidelines!.length > 0, "spawn promptGuidelines should be non-empty");
+	for (const g of spawnTool.promptGuidelines!) {
+		assert.ok(g.length > 10, "each spawn guideline should be non-trivial");
+	}
 });
 
 test("executeSpawn detects stale session before session creation", async () => {

--- a/agenticoding.test.ts
+++ b/agenticoding.test.ts
@@ -1832,7 +1832,7 @@ test("notebook rehydration rebuilds the latest epoch and enables notebook tools"
 });
 
 
-test("notebook rehydration respects a preset epoch and avoids duplicate active tools", async () => {
+test("notebook rehydration rebuilds from the latest persisted epoch and avoids duplicate active tools", async () => {
 	const pi = new MockPi();
 	pi.activeTools = ["read", "notebook_read", "notebook_index"];
 	const state = createState();
@@ -1847,15 +1847,85 @@ test("notebook rehydration respects a preset epoch and avoids duplicate active t
 				getBranch: () => [
 					{ type: "custom", customType: "notebook-entry", data: { epoch: 6, name: "stale", content: "old" } },
 					{ type: "custom", customType: "notebook-entry", data: { epoch: 7, name: "keep", content: "fresh" } },
-					{ type: "custom", customType: "notebook-entry", data: { epoch: 8, name: "future", content: "skip" } },
+					{ type: "custom", customType: "notebook-entry", data: { epoch: 8, name: "future", content: "latest" } },
 				],
 			},
 		},
 	);
 
-	assert.equal(state.epoch, 7);
-	assert.deepEqual(Array.from(state.notebookPages.entries()), [["keep", "fresh"]]);
+	assert.equal(state.epoch, 8);
+	assert.deepEqual(Array.from(state.notebookPages.entries()), [["future", "latest"]]);
 	assert.deepEqual(pi.activeTools, ["read", "notebook_read", "notebook_index"]);
+});
+
+
+test("notebook rehydration clears stale in-memory notebook state when persisted history is empty", async () => {
+	const pi = new MockPi();
+	const state = createState();
+	state.epoch = 7;
+	state.notebookPages.set("stale", "stale body");
+	registerNotebookRehydration(pi as any, state);
+	const [handler] = pi.handlers.get("session_start")!;
+
+	await handler(
+		{},
+		{
+			sessionManager: {
+				getBranch: () => [],
+			},
+		},
+	);
+
+	assert.equal(state.epoch, 0);
+	assert.deepEqual(Array.from(state.notebookPages.entries()), []);
+	assert.deepEqual(pi.activeTools, ["notebook_read", "notebook_index"]);
+});
+
+
+test("session_start rehydrates the latest persisted notebook state through the full hook chain", async () => {
+	resetNotebookWriteLock();
+	const pi = new MockPi();
+	pi.activeTools = ["read", "notebook_read"];
+	registerAgenticoding(pi as any);
+
+	try {
+		const notebookWrite = pi.tools.get("notebook_write");
+		await notebookWrite.execute(
+			"seed",
+			{ name: "stale-page", content: "stale body" },
+			undefined,
+			undefined,
+			makeTUICtx({ hasUI: false }),
+		);
+
+		const sessionStartHandlers = pi.handlers.get("session_start")!;
+		const ctx = {
+			hasUI: false,
+			getContextUsage: () => null,
+			sessionManager: {
+				getBranch: () => [
+					{ type: "custom", customType: "notebook-entry", data: { epoch: 6, name: "stale", content: "old" } },
+					{ type: "custom", customType: "notebook-entry", data: { epoch: 8, name: "keep", content: "fresh" } },
+					{ type: "custom", customType: "notebook-entry", data: { epoch: 8, name: "keep", content: "newer" } },
+				],
+			},
+		};
+		for (const sessionStart of sessionStartHandlers) {
+			await sessionStart({ reason: "resume" }, ctx as any);
+		}
+
+		const notebookIndex = pi.tools.get("notebook_index");
+		const notebookRead = pi.tools.get("notebook_read");
+		const indexResult = await notebookIndex.execute("1", {}, undefined, undefined, {} as any);
+		assert.deepEqual(indexResult.details.entries, ["keep"]);
+
+		const readResult = await notebookRead.execute("2", { name: "keep" }, undefined, undefined, {} as any);
+		assert.equal(readResult.details.found, true);
+		assert.equal(readResult.details.body, "newer");
+		assert.deepEqual(pi.activeTools, ["read", "notebook_read", "notebook_index"]);
+	} finally {
+		resetNotebookWriteLock();
+	}
 });
 
 test("notebook tools add/get/list return stable contract details", async () => {
@@ -2187,6 +2257,34 @@ test("saveNotebookPage truncates oversized content before persisting", async () 
 	assert.equal(result.preview, "first line");
 	assert.match(persisted, /^first line/m);
 	resetNotebookWriteLock();
+});
+
+
+test("resetState clears epoch and the next notebook write starts a fresh generation", async () => {
+	resetNotebookWriteLock();
+	const pi = new MockPi();
+	const state = createState();
+	const originalNow = Date.now;
+
+	try {
+		Date.now = () => 1000;
+		await saveNotebookPage(pi as any, state, "entry-a", "first");
+		await saveNotebookPage(pi as any, state, "entry-b", "second");
+		assert.equal(state.epoch, 1000);
+		assert.equal(pi.appendedEntries[0].data.epoch, 1000);
+		assert.equal(pi.appendedEntries[1].data.epoch, 1000);
+
+		resetState(state);
+		assert.equal(state.epoch, 0);
+
+		Date.now = () => 2000;
+		await saveNotebookPage(pi as any, state, "entry-c", "third");
+		assert.equal(state.epoch, 2000);
+		assert.equal(pi.appendedEntries[2].data.epoch, 2000);
+	} finally {
+		Date.now = originalNow;
+		resetNotebookWriteLock();
+	}
 });
 
 test("nested spawn invalidate rebuilds from the attached session transcript", () => {

--- a/agenticoding.test.ts
+++ b/agenticoding.test.ts
@@ -564,6 +564,63 @@ test("context injects a boundary nudge below 30% after an explicit topic change"
 	assert.match(result.messages[1].content, /Notebook topic changed from oauth to billing/);
 });
 
+
+test("context injects a no-topic nudge when context is high", async () => {
+	const pi = new MockPi();
+	registerAgenticoding(pi as any);
+	const [handler] = pi.handlers.get("context")!;
+
+	const result = await handler(
+		{ messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+		{ getContextUsage: () => ({ percent: 70 }) },
+	);
+
+	assert.equal(result.messages.length, 2);
+	assert.equal(result.messages[1].role, "custom");
+	assert.equal(result.messages[1].customType, "agenticoding-watchdog");
+	assert.equal(result.messages[1].display, false);
+	assert.match(result.messages[1].content, /No active notebook topic is set/);
+	assert.match(result.messages[1].content, /Assign a fresh topic in the next clean context after handoff/i);
+});
+
+
+test("context consumes a boundary hint after the first injected nudge", async () => {
+	const pi = new MockPi();
+	registerAgenticoding(pi as any);
+	const [handler] = pi.handlers.get("context")!;
+	await pi.commands.get("notebook")!.handler("oauth", { hasUI: false, getContextUsage: () => null });
+	await pi.commands.get("notebook")!.handler("billing", { hasUI: false, getContextUsage: () => null });
+
+	const first = await handler(
+		{ messages: [{ role: "user", content: "hi", timestamp: 1 }] },
+		{ getContextUsage: () => ({ percent: 20 }) },
+	);
+	assert.match(first.messages[1].content, /Notebook topic changed from oauth to billing/);
+
+	const second = await handler(
+		{ messages: [{ role: "user", content: "hi", timestamp: 2 }] },
+		{ getContextUsage: () => ({ percent: 20 }) },
+	);
+	assert.equal(second, undefined);
+});
+
+
+test("buildNudge handles null percent and boundary hints before topic guidance", () => {
+	const boundary = buildNudge(
+		{
+			activeNotebookTopic: "oauth",
+			pendingTopicBoundaryHint: { from: "oauth", to: "billing", source: "human" },
+		},
+		null,
+	);
+	assert.match(boundary, /Notebook topic changed from oauth to billing/);
+	assert.doesNotMatch(boundary, /Active notebook topic: oauth/);
+
+	const noTopic = buildNudge({ activeNotebookTopic: null, pendingTopicBoundaryHint: null }, null);
+	assert.match(noTopic, /Topic-aware context reminder/);
+	assert.match(noTopic, /No active notebook topic is set/);
+});
+
 test("watchdog stays advisory when a requested handoff is not completed", async () => {
 	const pi = new MockPi();
 	const state = createState();
@@ -2089,6 +2146,34 @@ test("/notebook exits cleanly when headless", async () => {
 	await assert.doesNotReject(() => pi.commands.get("notebook")!.handler("", { hasUI: false }));
 });
 
+
+test("/notebook <topic> notifies with info on first set and warning on boundary change", async () => {
+	const pi = new MockPi();
+	registerAgenticoding(pi as any);
+	const notifications: Array<{ message: string; level: string }> = [];
+	const statuses = new Map<string, string | undefined>();
+	const widgets = new Map<string, string[] | undefined>();
+	const ctx = {
+		hasUI: true,
+		getContextUsage: () => ({ percent: 20 }),
+		ui: {
+			theme: { fg: (_name: string, text: string) => text },
+			notify: (message: string, level: string) => { notifications.push({ message, level }); },
+			setStatus: (key: string, status: string | undefined) => { statuses.set(key, status); },
+			setWidget: (key: string, content: string[] | undefined) => { widgets.set(key, content); },
+		},
+	};
+
+	await pi.commands.get("notebook")!.handler("oauth", ctx as any);
+	await pi.commands.get("notebook")!.handler("billing", ctx as any);
+
+	assert.deepEqual(notifications[0], { message: "Active notebook topic: oauth", level: "info" });
+	assert.match(notifications[1].message, /Active notebook topic changed: oauth → billing/);
+	assert.equal(notifications[1].level, "warning");
+	assert.equal(statuses.get(STATUS_KEY_TOPIC), "🧭 billing");
+	assert.equal(widgets.get(WIDGET_KEY_WARNING), undefined);
+});
+
 test("/notebook empty overlay renders empty state and closes on input", async () => {
 	const pi = new MockPi();
 	registerAgenticoding(pi as any);
@@ -3146,7 +3231,7 @@ test("topic helpers manage the active notebook topic lifecycle", () => {
 	assert.equal(state.pendingTopicBoundaryHint, null);
 });
 
-test("notebook_topic_set establishes a fresh topic and refuses overrides", async () => {
+test("notebook_topic_set establishes a fresh topic, is idempotent, and refuses overrides", async () => {
 	const pi = new MockPi();
 	const state = createState();
 	registerNotebookTopicTool(pi as any, state);
@@ -3157,7 +3242,39 @@ test("notebook_topic_set establishes a fresh topic and refuses overrides", async
 	assert.equal(state.activeNotebookTopic, "oauth");
 	assert.equal(state.activeNotebookTopicSource, "agent");
 
-	await assert.rejects(() => tool.execute("2", { topic: "billing" }), /already exists/);
+	const second = await tool.execute("2", { topic: "oauth" });
+	assert.equal(second.details.changed, false);
+	assert.equal(second.details.source, "agent");
+	assert.match(second.content[0].text, /already set to "oauth"/i);
+
+	await assert.rejects(() => tool.execute("3", { topic: "billing" }), /already exists/);
+});
+
+
+test("notebook_topic_set preserves human authority, stays idempotent for equal topics, and rejects empty normalized topics", async () => {
+	const pi = new MockPi();
+	const state = createState();
+	registerNotebookTopicTool(pi as any, state);
+	const tool = pi.tools.get("notebook_topic_set");
+
+	setActiveNotebookTopic(state, "oauth", "human");
+	const same = await tool.execute("1", { topic: "OAuth" });
+	assert.equal(same.details.changed, false);
+	assert.equal(same.details.source, "human");
+	assert.match(same.content[0].text, /already set to "oauth"/i);
+	await assert.rejects(
+		() => tool.execute("2", { topic: "billing" }),
+		/human-set notebook topic is authoritative/i,
+	);
+
+	const freshPi = new MockPi();
+	const freshState = createState();
+	registerNotebookTopicTool(freshPi as any, freshState);
+	const freshTool = freshPi.tools.get("notebook_topic_set");
+	await assert.rejects(
+		() => freshTool.execute("3", { topic: "@@@" }),
+		/notebook topic cannot be empty/i,
+	);
 });
 
 test("buildNudge no longer emits the old percent-only handoff text", () => {
@@ -3167,41 +3284,38 @@ test("buildNudge no longer emits the old percent-only handoff text", () => {
 	assert.match(old, /prefer spawn/i);
 });
 
-test("CONTEXT_PRIMER frames the notebook as durable grounding and handoff as direction", () => {
-	// No stale "ledger" references
+
+test("CONTEXT_PRIMER states the notebook, topic, and handoff contracts", () => {
 	assert.doesNotMatch(CONTEXT_PRIMER, /ledger/i,
 		"CONTEXT_PRIMER should contain zero stale ledger references after the rename");
 
-	// Structural: section headers exist
-	// Structural: section headers exist
-	assert.match(CONTEXT_PRIMER, /### Notebook/);
-	assert.match(CONTEXT_PRIMER, /### Active notebook topic/);
-	assert.match(CONTEXT_PRIMER, /### Handoff/);
-	assert.match(CONTEXT_PRIMER, /### Rules/);
+	const notebookParts = CONTEXT_PRIMER.split("### Notebook");
+	const topicParts = CONTEXT_PRIMER.split("### Active notebook topic");
+	const handoffParts = CONTEXT_PRIMER.split("### Handoff");
+	const rulesParts = CONTEXT_PRIMER.split("### Rules");
+	assert.equal(notebookParts.length, 2);
+	assert.equal(topicParts.length, 2);
+	assert.equal(handoffParts.length, 2);
+	assert.equal(rulesParts.length, 2);
 
-	// Structural: Rules section names the tools it references
-	const rules = CONTEXT_PRIMER.split("### Rules")[1];
-	assert.ok(rules.includes("notebook_index"), "Rules should mention notebook_index");
-	assert.ok(rules.includes("notebook_read"), "Rules should mention notebook_read");
-	assert.ok(rules.includes("distilled next task"), "Rules should frame handoff as the next task");
+	const notebookSection = notebookParts[1].split("### Active notebook topic")[0];
+	const topicSection = topicParts[1].split("### Handoff")[0];
+	const handoffSection = handoffParts[1].split("### Rules")[0];
+	const rulesSection = rulesParts[1];
 
-	// Conceptual: Notebook section contains durable grounding concepts
-	const notebookSection = CONTEXT_PRIMER.split("### Notebook")[1].split("### Active notebook topic")[0].toLowerCase();
-	for (const concept of ["future contexts", "subject", "architecture", "constraints", "verified facts"]) {
-		assert.ok(notebookSection.includes(concept), `Notebook section should mention "${concept}"`);
-		}
-
-	const topicSection = CONTEXT_PRIMER.split("### Active notebook topic")[1].split("### Handoff")[0].toLowerCase();
-	assert.ok(topicSection.includes("semantic frame"), "Topic section should mention semantic frame");
-	assert.ok(topicSection.includes("prefer spawn"), "Topic section should bias spawn inside a topic");
-	assert.ok(topicSection.includes("prefer handoff"), "Topic section should bias handoff across topics");
-
-	const handoffSection = CONTEXT_PRIMER.split("### Handoff")[1].split("### Rules")[0].toLowerCase();
-	assert.ok(handoffSection.includes("situational context"), "Handoff should mention situational context");
-	assert.ok(handoffSection.includes("do not duplicate"), "Handoff should avoid duplicating notebook content");
+	assert.match(notebookSection, /notebook_index/);
+	assert.match(notebookSection, /notebook_read/);
+	assert.match(notebookSection, /future contexts/i);
+	assert.match(topicSection, /semantic frame/i);
+	assert.match(topicSection, /prefer spawn/i);
+	assert.match(topicSection, /prefer handoff/i);
+	assert.match(handoffSection, /handoff/i);
+	assert.match(handoffSection, /notebook/i);
+	assert.match(rulesSection, /one subject, thread, or subsystem/i);
 });
 
-test("before_agent_start injects the notebook primer and live notebook pages", async () => {
+
+test("before_agent_start injects notebook contracts plus live topic and page data", async () => {
 	const pi = new MockPi();
 	registerAgenticoding(pi as any);
 	await pi.commands.get("notebook")!.handler("oauth", { hasUI: false, getContextUsage: () => null });
@@ -3216,10 +3330,21 @@ test("before_agent_start injects the notebook primer and live notebook pages", a
 	assert.match(result.systemPrompt, /## Active Notebook Topic/);
 	assert.match(result.systemPrompt, /Current topic: `oauth`/);
 	assert.match(result.systemPrompt, /## Active Notebook Pages/);
-	assert.match(result.systemPrompt, /The following pages are available via notebook_read by name:/);
-	assert.ok(result.systemPrompt.includes("Reference pages by name"), "should reference pages by name");
+	assert.match(result.systemPrompt, /notebook_read/);
+	assert.match(result.systemPrompt, /Reference pages by name/i);
 	assert.match(result.systemPrompt, /alpha: first line/);
-	assert.ok(result.systemPrompt.includes(CONTEXT_PRIMER), "system prompt should include CONTEXT_PRIMER verbatim");
+});
+
+
+test("before_agent_start injects no-topic guidance when the topic is unset", async () => {
+	const pi = new MockPi();
+	registerAgenticoding(pi as any);
+	const [handler] = pi.handlers.get("before_agent_start")!;
+	const result = await handler({ systemPrompt: "Base system prompt." }, makeTUICtx({ hasUI: false }));
+
+	assert.match(result.systemPrompt, /## Active Notebook Topic/);
+	assert.match(result.systemPrompt, /No active notebook topic is set\./);
+	assert.match(result.systemPrompt, /notebook_topic_set/);
 });
 
 test("notebook tool definitions omit prompt hints by default", () => {

--- a/handoff/command.ts
+++ b/handoff/command.ts
@@ -37,7 +37,7 @@ export function registerHandoffCommand(pi: ExtensionAPI, state: AgenticodingStat
 			}
 
 			pi.sendUserMessage(
-				`Handoff direction: ${direction}\n\nPrepare a real handoff in the current session and current context. Before calling the handoff tool, capture any reusable state in the ledger if needed. Then complete the picture in a concise but sufficiently detailed handoff brief and call the handoff tool in this turn. Preserve the important knowledge that is still only present in the current context so the next clean context can start well without re-deriving it. Use any structure that makes the next work unambiguous. Include findings, current state, unresolved questions, failed paths worth avoiding, next steps, refs, constraints, and spawn ideas when useful. Reference ledger entries by name when relevant.`,
+				`Handoff direction: ${direction}\n\nPrepare a handoff in the current session. First, save any durable reusable knowledge to the notebook: findings worth keeping, constraints discovered, decisions made, or other grounding future contexts will need. Then draft a concise but sufficiently detailed handoff brief capturing only the remaining situational context: current state, blockers, unresolved questions, failed paths worth avoiding, and next steps. The next context will read the notebook on demand, so do not duplicate notebook content in the brief. Use any structure that makes the next work unambiguous. Reference notebook pages by name when relevant.`,
 				ctx.isIdle() ? undefined : { deliverAs: "followUp" },
 			);
 		},

--- a/handoff/compact.ts
+++ b/handoff/compact.ts
@@ -7,6 +7,7 @@
 
 import type { ExtensionAPI, ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent";
 import type { AgenticodingState } from "../state.js";
+import { clearActiveNotebookTopic } from "../notebook/topic.js";
 import { STATUS_KEY_HANDOFF } from "../tui.js";
 
 function getImpossibleKeptId(branchEntries: SessionEntry[]): string {
@@ -23,6 +24,7 @@ export function registerHandoffCompaction(pi: ExtensionAPI, state: AgenticodingS
 
 		state.pendingHandoff = null;
 		state.pendingRequestedHandoff = null;
+		clearActiveNotebookTopic(state);
 
 		// Clear the handoff progress indicator now that compaction is consuming it
 		if (ctx.hasUI) {

--- a/handoff/tool.ts
+++ b/handoff/tool.ts
@@ -4,9 +4,9 @@
  * Tools can trigger compaction directly, so handoff is implemented as a
  * deliberate compaction that replaces noisy context with a clean restart brief.
  *
- * The brief should complete the picture: preserve the important knowledge that
- * is still only present in the current context, while referenced ledger entry
- * bodies seed the post-handoff context immediately.
+ * The brief should complete the picture: preserve the important situational
+ * context that is still only present in the current turn, while notebook pages
+ * remain durable grounding fetched on demand in the next context.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -14,69 +14,26 @@ import { Type } from "typebox";
 import type { AgenticodingState } from "../state.js";
 import { STATUS_KEY_HANDOFF } from "../tui.js";
 
-const MAX_INLINE_ENTRIES = 3;
-const MAX_INLINE_CHARS = 4000;
-
-/**
- * Extract names of existing ledger entries referenced in the task text.
- * Returns up to MAX_INLINE_ENTRIES entries with their full bodies,
- * capped at MAX_INLINE_CHARS total.
- */
-function extractReferencedLedgerEntries(
-	task: string,
-	state: AgenticodingState,
-): { name: string; body: string }[] {
-	const entryNames = Array.from(state.ledger.keys()).sort();
-	const matched: { name: string; body: string }[] = [];
-	const seen = new Set<string>();
-	let totalChars = 0;
-
-	for (const name of entryNames) {
-		if (task.includes(name) && !seen.has(name)) {
-			const body = state.ledger.get(name);
-			if (body) {
-				const chars = body.length;
-				if (totalChars + chars <= MAX_INLINE_CHARS && matched.length < MAX_INLINE_ENTRIES) {
-					matched.push({ name, body });
-					seen.add(name);
-					totalChars += chars;
-				}
-			}
-		}
-	}
-
-	return matched;
-}
-
 /**
  * Build the enriched task that becomes the compaction summary.
  *
- * Shape: handoff primer + inlined ledger bodies + original task.
+ * Shape: handoff primer + original task.
  */
-function buildEnrichedTask(
-	task: string,
-	state: AgenticodingState,
-): string {
-	const refs = extractReferencedLedgerEntries(task, state);
-
+function buildEnrichedTask(task: string): string {
 	const parts: string[] = [
 		"## Handoff — Continue Previous Work",
 		"",
-		"You are continuing a previous agent's work in a clean context. Available knowledge:",
-		"- Use `ledger_get` to retrieve detailed entries by name on demand",
+		"You are continuing a previous agent's work in a clean context. Use the available knowledge correctly:",
+		"- Notebook pages hold durable grounding knowledge; fetch them with `notebook_read`",
+		"- This handoff brief holds the distilled next task and immediate situational context",
+		"- Use `notebook_index` to scan available pages when needed",
 		"- Use `spawn` to delegate isolated subtasks to child agents",
-		"- Build on ledger knowledge and the handoff brief rather than reconstructing old context",
-		"- Treat the handoff brief as the missing picture that survived the cut",
+		"- Build on notebook grounding and this brief rather than reconstructing old context",
+		"",
+		"## Task",
+		"",
+		task,
 	];
-
-	if (refs.length > 0) {
-		parts.push("", "### Inlined Ledger Context");
-		for (const { name, body } of refs) {
-			parts.push("", `Ledger: \`${name}\``, body, "---");
-		}
-	}
-
-	parts.push("", "## Task", "", task);
 
 	return parts.join("\n");
 }
@@ -89,8 +46,8 @@ export function registerHandoffTool(
 		name: "handoff",
 		label: "Handoff",
 		description:
-			"Replace the active context with a compact handoff task at the end of " +
-			"the current turn while keeping full history in the session file.\n\n" +
+			"Replace the active context with a compact task brief at the end of " +
+			"the current turn while keeping full history in the session file. Handoff clears the active notebook topic so the next clean context can assign a fresh one.\n\n" +
 			"WHEN TO USE:\n" +
 			"  1. Context past ~30% and the current job is no longer cleanly " +
 			"represented near the front of attention.\n" +
@@ -100,14 +57,13 @@ export function registerHandoffTool(
 			"Rule: one context, one job. When the job changes, call handoff.\n\n" +
 			"AFTER HANDOFF the LLM sees:\n" +
 			"  • System prompt + context primer\n" +
-			"  • The handoff task — as a compaction summary at the top of context\n" +
-			"  • All ledger entries — accessible via ledger_get / ledger_list",
+			"  • The handoff task — the distilled next work at the top of context\n" +
+			"  • All notebook pages — durable grounding accessible via notebook_read / notebook_index",
 
 		promptSnippet: "Pivot to a new job via deliberate handoff compaction",
 		promptGuidelines: [
-			"Call handoff when the job changes, or when context is past ~30% and noisy. " +
-				"Capture reusable state in the ledger if needed, then draft a concise but " +
-				"sufficiently detailed brief that completes the picture for the next clean context.",
+			"Before handoff, promote any missing durable grounding knowledge to the notebook. " +
+				"Then draft a concise but sufficiently detailed brief with the distilled next task and immediate starting state for the next clean context. The active notebook topic will reset after handoff, so the next context should assign a fresh topic from the brief or user direction.",
 		],
 
 		executionMode: "sequential",
@@ -116,14 +72,14 @@ export function registerHandoffTool(
 			task: Type.String({
 				description:
 					"What to do next. A concise but sufficiently detailed handoff brief. " +
-					"This becomes the FIRST thing the LLM sees after handoff. Complete the " +
-					"picture by preserving the important knowledge still missing from the ledger, " +
-					"then make the next work unambiguous using any structure you want.",
+					"This becomes the FIRST thing the LLM sees after handoff. Capture the distilled next task, " +
+					"immediate starting state, blockers, failed paths worth avoiding, and relevant notebook page names. " +
+					"The notebook is the long-term grounding store; this brief should carry only the remaining situational context.",
 			}),
 		}),
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const enrichedTask = buildEnrichedTask(params.task, state);
+			const enrichedTask = buildEnrichedTask(params.task);
 			state.pendingHandoff = { task: enrichedTask, source: "tool" };
 			if (state.pendingRequestedHandoff) {
 				state.pendingRequestedHandoff.toolCalled = true;

--- a/index.ts
+++ b/index.ts
@@ -3,12 +3,12 @@
  *
  * Wires together the three primitives:
  *   spawn     — delegate isolated work to child contexts
- *   ledger    — sparse continuity cache
+ *   notebook   — durable cross-context grounding
  *   handoff   — deliberate task pivot via compaction
  *
  * Also registers:
  *   - watchdog (advisory primacy-zone reminder after each turn)
- *   - system prompt injection (CONTEXT_PRIMER, nudge, ledger listing)
+ *   - system prompt injection (CONTEXT_PRIMER, nudge, notebook listing)
  *   - state reset on /new
  */
 
@@ -23,8 +23,8 @@ import {
 import { createState, resetState, type AgenticodingState } from "./state.js";
 import { CONTEXT_PRIMER } from "./system-prompt.js";
 import { buildNudge, registerWatchdog } from "./watchdog.js";
-import { registerLedgerTools } from "./ledger/tools.js";
-import { registerLedgerRehydration } from "./ledger/rehydration.js";
+import { registerNotebookTools } from "./notebook/tools.js";
+import { registerNotebookRehydration } from "./notebook/rehydration.js";
 import { registerHandoffTool } from "./handoff/tool.js";
 import { registerHandoffCommand } from "./handoff/command.js";
 import { registerHandoffCompaction } from "./handoff/compact.js";
@@ -34,27 +34,27 @@ import {
 	WIDGET_KEY_WARNING,
 	updateIndicators,
 } from "./tui.js";
-import { formatEntryPreview } from "./ledger/store.js";
+import { formatPagePreview } from "./notebook/store.js";
 
 export default function (pi: ExtensionAPI): void {
 	const state: AgenticodingState = createState();
 
 	// ── Register all tools ──────────────────────────────────────────
-	registerLedgerTools(pi, state);
+	registerNotebookTools(pi, state);
 	registerHandoffTool(pi, state);
 	registerSpawnTool(pi, state);
 
 	// ── Register event handlers ─────────────────────────────────────
 	registerWatchdog(pi, state);
-	registerLedgerRehydration(pi, state);
+	registerNotebookRehydration(pi, state);
 	registerHandoffCompaction(pi, state);
 
 	// ── Register commands ───────────────────────────────────────────
 	registerHandoffCommand(pi, state);
 
-	// ── /ledger command — interactive entry selector ────────────────
-	pi.registerCommand("ledger", {
-		description: "Select a ledger entry to preview",
+	// ── /notebook command — interactive page selector ────────────────
+	pi.registerCommand("notebook", {
+		description: "Select a notebook page to preview",
 		handler: async (_args, ctx) => {
 			if (!ctx.hasUI) {
 				return;
@@ -67,22 +67,22 @@ export default function (pi: ExtensionAPI): void {
 					new DynamicBorder((s: string) => theme.fg("accent", s)),
 				);
 				container.addChild(
-					new Text(theme.fg("accent", theme.bold(` Ledger (${state.ledger.size} entries) `)), 1, 0),
+					new Text(theme.fg("accent", theme.bold(` Notebook (${state.notebookPages.size} pages) `)), 1, 0),
 				);
 
-				const entries = Array.from(state.ledger.entries()).sort(([a], [b]) => a.localeCompare(b));
+				const entries = Array.from(state.notebookPages.entries()).sort(([a], [b]) => a.localeCompare(b));
 				let selectList: SelectList | undefined;
 				let finished = false;
 
 				if (entries.length === 0) {
 					container.addChild(
-						new Text(theme.fg("dim", " (empty) — use ledger_add to create entries"), 1, 0),
+						new Text(theme.fg("dim", " (empty) — use notebook_write to create pages"), 1, 0),
 					);
 				} else {
 					const items: SelectItem[] = entries.map(([name, content]) => ({
 						value: name,
 						label: name,
-						description: formatEntryPreview(content),
+						description: formatPagePreview(content),
 					}));
 
 					selectList = new SelectList(items, Math.min(items.length, 10), {
@@ -95,7 +95,7 @@ export default function (pi: ExtensionAPI): void {
 					selectList.onSelect = ({ value }) => {
 						// Guard: selectList is set to undefined below, so this handler
 						// cannot fire twice — no re-entrancy guard needed here.
-						const body = state.ledger.get(value);
+						const body = state.notebookPages.get(value);
 						if (!body) { done(); return; }
 						// Switch to body view: show the selected entry body inline
 						container.clear();
@@ -142,7 +142,7 @@ export default function (pi: ExtensionAPI): void {
 		},
 	});
 
-	// ── before_agent_start: inject context primer + ledger ─────────
+	// ── before_agent_start: inject context primer + notebook ───────
 	pi.on("before_agent_start", async (event, ctx: ExtensionContext) => {
 		// Update TUI indicators before each user-prompt agent run
 		updateIndicators(ctx, state);
@@ -163,9 +163,9 @@ export default function (pi: ExtensionAPI): void {
 				})
 				.join("\n");
 			parts.push(
-				`\n## Active Ledger Entries\n` +
-					`The following entries are available via ledger_get by name:\n${listing}\n` +
-					`Reference entries by name — never paste bodies into prompts.`,
+				`\n## Active Notebook Pages\n` +
+					`The following pages are available via notebook_read by name:\n${listing}\n` +
+					`Reference pages by name — never paste bodies into prompts.`,
 			);
 		}
 

--- a/index.ts
+++ b/index.ts
@@ -204,18 +204,23 @@ export default function (pi: ExtensionAPI): void {
 	// ── context: inject primacy-zone nudge before each LLM call ────
 	pi.on("context", async (event, ctx: ExtensionContext) => {
 		const usage = ctx.getContextUsage();
-		if (!usage || usage.percent === null || usage.percent < 30) {
+		const percent = usage?.percent ?? null;
+		if (usage && usage.percent !== null) {
+			state.lastContextPercent = usage.percent;
+		}
+		if (!state.pendingTopicBoundaryHint && (percent === null || percent < 30)) {
 			return;
 		}
 
-		state.lastContextPercent = usage.percent;
+		const nudge = buildNudge(state, percent);
+		state.pendingTopicBoundaryHint = null;
 		return {
 			messages: [
 				...event.messages,
 				{
 					role: "custom",
 					customType: "agenticoding-watchdog",
-					content: buildNudge(usage.percent),
+					content: nudge,
 					display: false,
 					timestamp: Date.now(),
 				},

--- a/index.ts
+++ b/index.ts
@@ -25,12 +25,15 @@ import { CONTEXT_PRIMER } from "./system-prompt.js";
 import { buildNudge, registerWatchdog } from "./watchdog.js";
 import { registerNotebookTools } from "./notebook/tools.js";
 import { registerNotebookRehydration } from "./notebook/rehydration.js";
+import { registerNotebookTopicTool } from "./notebook/topic-tool.js";
+import { setActiveNotebookTopic } from "./notebook/topic.js";
 import { registerHandoffTool } from "./handoff/tool.js";
 import { registerHandoffCommand } from "./handoff/command.js";
 import { registerHandoffCompaction } from "./handoff/compact.js";
 import { registerSpawnTool } from "./spawn/index.js";
 import {
 	STATUS_KEY_HANDOFF,
+	STATUS_KEY_TOPIC,
 	WIDGET_KEY_WARNING,
 	updateIndicators,
 } from "./tui.js";
@@ -41,6 +44,7 @@ export default function (pi: ExtensionAPI): void {
 
 	// ── Register all tools ──────────────────────────────────────────
 	registerNotebookTools(pi, state);
+	registerNotebookTopicTool(pi, state);
 	registerHandoffTool(pi, state);
 	registerSpawnTool(pi, state);
 
@@ -54,8 +58,20 @@ export default function (pi: ExtensionAPI): void {
 
 	// ── /notebook command — interactive page selector ────────────────
 	pi.registerCommand("notebook", {
-		description: "Select a notebook page to preview",
-		handler: async (_args, ctx) => {
+		description: "Select a notebook page to preview, or set the active notebook topic with /notebook <topic>",
+		handler: async (args, ctx) => {
+			const topicArg = args.trim();
+			if (topicArg) {
+				const result = setActiveNotebookTopic(state, topicArg, "human");
+				if (ctx.hasUI) {
+					const message = result.boundaryHint
+						? `Active notebook topic changed: ${result.boundaryHint.from} → ${result.boundaryHint.to}. This is a likely task boundary; handoff is recommended before continuing.`
+						: `Active notebook topic: ${result.current}`;
+					ctx.ui.notify(message, result.boundaryHint ? "warning" : "info");
+				}
+				updateIndicators(ctx, state);
+				return;
+			}
 			if (!ctx.hasUI) {
 				return;
 			}
@@ -152,12 +168,25 @@ export default function (pi: ExtensionAPI): void {
 		// Inject context management primer at the end of the system prompt
 		parts.push("\n" + CONTEXT_PRIMER);
 
-		// Inject ledger listing so the LLM always knows what's available
-		const entryNames = Array.from(state.ledger.keys()).sort();
+		if (state.activeNotebookTopic) {
+			parts.push(
+				`\n## Active Notebook Topic\n` +
+				`Current topic: \`${state.activeNotebookTopic}\` (${state.activeNotebookTopicSource ?? "unknown"}-set).\n` +
+				`Treat this as the current semantic frame. If new work fits it, prefer spawn for isolated noisy subtasks. If it does not fit it, prefer handoff over dragging stale context forward.`,
+			);
+		} else {
+			parts.push(
+				`\n## Active Notebook Topic\n` +
+				`No active notebook topic is set. Early in the next substantive task, assign a short stable topic with \`notebook_topic_set\`. Human-set topics are authoritative.`,
+			);
+		}
+
+		// Inject notebook listing so the LLM always knows what's available
+		const entryNames = Array.from(state.notebookPages.keys()).sort();
 		if (entryNames.length > 0) {
 			const listing = entryNames
 				.map((name) => {
-					const content = state.ledger.get(name)!;
+					const content = state.notebookPages.get(name)!;
 					const firstLine = (content.split("\n")[0] ?? "").slice(0, 80);
 					return `  ${name}: ${firstLine}`;
 				})
@@ -201,6 +230,7 @@ export default function (pi: ExtensionAPI): void {
 			// Clear any stale TUI indicators from the previous session
 			if (ctx.hasUI) {
 				ctx.ui.setStatus(STATUS_KEY_HANDOFF, undefined);
+				ctx.ui.setStatus(STATUS_KEY_TOPIC, undefined);
 				ctx.ui.setWidget(WIDGET_KEY_WARNING, undefined);
 			}
 		}

--- a/notebook/rehydration.ts
+++ b/notebook/rehydration.ts
@@ -1,9 +1,10 @@
 /**
- * Ledger rehydration for the agenticoding extension.
+ * Notebook rehydration for the agenticoding extension.
  *
  * A session_start handler that scans the current branch newest-to-oldest for
- * persisted ledger-entry custom entries, rebuilds the in-memory state.ledger
- * Map (newest wins per name), and ensures ledger_get / ledger_list are active.
+ * persisted notebook-entry (and legacy ledger-entry) custom entries, rebuilds
+ * the in-memory state.notebookPages Map (newest wins per name), and ensures
+ * notebook_read / notebook_index are active.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -11,21 +12,25 @@ import type { AgenticodingState } from "../state.js";
 
 // ── Types ─────────────────────────────────────────────────────────────
 
-interface LedgerEntryData {
+interface NotebookEntryData {
 	version: number;
 	epoch: number;
 	name: string;
 	content: string;
 }
 
-interface LedgerCandidate {
+interface NotebookCandidate {
 	epoch: number;
 	content: string;
 }
 
+// ── Rehydration entry types ───────────────────────────────────────────
+
+const ENTRY_TYPES = new Set(["notebook-entry", "ledger-entry"]);
+
 // ── Registration ──────────────────────────────────────────────────────
 
-export function registerLedgerRehydration(
+export function registerNotebookRehydration(
 	pi: ExtensionAPI,
 	state: AgenticodingState,
 ): void {
@@ -33,60 +38,58 @@ export function registerLedgerRehydration(
 		const branch = ctx.sessionManager.getBranch();
 
 		// Scan newest-to-oldest; first occurrence of each name wins (newest).
-		const candidates = new Map<string, LedgerCandidate>();
+		const candidates = new Map<string, NotebookCandidate>();
 
 		for (let i = branch.length - 1; i >= 0; i--) {
 			const entry = branch[i];
 
 			if (
 				entry.type !== "custom" ||
-				(entry as Record<string, unknown>).customType !== "ledger-entry"
+				!ENTRY_TYPES.has((entry as Record<string, unknown>).customType as string)
 			) {
 				continue;
 			}
 
-			const data = (entry as Record<string, unknown>).data as LedgerEntryData | undefined;
+			const data = (entry as Record<string, unknown>).data as NotebookEntryData | undefined;
 			if (!data?.name || typeof data.content !== "string") continue;
 
 			// Skip if we already have a newer version of this name
 			if (candidates.has(data.name)) continue;
 
 			candidates.set(data.name, {
-				epoch: data.epoch,
+				epoch: data.epoch ?? 0,
 				content: data.content,
 			});
 		}
 
-		if (candidates.size === 0) return;
-
-		// Determine the current epoch from candidates.
-		// If state.epoch is already set (e.g., from first add before rehydration),
-		// filter to entries matching that epoch. Otherwise adopt the max epoch found.
+		// Pick the epoch from the newest candidate across all names
 		let currentEpoch = state.epoch;
-		if (currentEpoch === 0) {
-			for (const [, c] of candidates) {
-				if (c.epoch > currentEpoch) currentEpoch = c.epoch;
+		for (const candidate of candidates.values()) {
+			if (candidate.epoch > currentEpoch) {
+				currentEpoch = candidate.epoch;
 			}
+		}
+		if (currentEpoch > state.epoch) {
 			state.epoch = currentEpoch;
 		}
 
-		// Rebuild state.ledger, filtering by epoch
-		state.ledger.clear();
+		// Rebuild state.notebookPages, filtering by epoch
+		state.notebookPages.clear();
 		for (const [name, candidate] of candidates) {
 			if (candidate.epoch === currentEpoch) {
-				state.ledger.set(name, candidate.content);
+				state.notebookPages.set(name, candidate.content);
 			}
 		}
 
-		// Ensure ledger_get and ledger_list are active so the LLM can fetch entries
+		// Ensure notebook_read and notebook_index are active so the LLM can fetch pages
 		const active = pi.getActiveTools();
 		let changed = false;
-		if (!active.includes("ledger_get")) {
-			active.push("ledger_get");
+		if (!active.includes("notebook_read")) {
+			active.push("notebook_read");
 			changed = true;
 		}
-		if (!active.includes("ledger_list")) {
-			active.push("ledger_list");
+		if (!active.includes("notebook_index")) {
+			active.push("notebook_index");
 			changed = true;
 		}
 		if (changed) pi.setActiveTools(active);

--- a/notebook/rehydration.ts
+++ b/notebook/rehydration.ts
@@ -62,16 +62,16 @@ export function registerNotebookRehydration(
 			});
 		}
 
-		// Pick the epoch from the newest candidate across all names
-		let currentEpoch = state.epoch;
+		// Rehydrate from persisted history: branch entries are the durable
+		// notebook source of truth. Pick the latest persisted epoch across the
+		// surviving names, then rebuild the in-memory view from that generation.
+		let currentEpoch = 0;
 		for (const candidate of candidates.values()) {
 			if (candidate.epoch > currentEpoch) {
 				currentEpoch = candidate.epoch;
 			}
 		}
-		if (currentEpoch > state.epoch) {
-			state.epoch = currentEpoch;
-		}
+		state.epoch = currentEpoch;
 
 		// Rebuild state.notebookPages, filtering by epoch
 		state.notebookPages.clear();

--- a/notebook/store.ts
+++ b/notebook/store.ts
@@ -1,7 +1,7 @@
 /**
- * Shared ledger storage helpers.
+ * Shared notebook storage helpers.
  *
- * Keeps parent and spawned-child ledger writes on the same persistence path.
+ * Keeps parent and spawned-child notebook writes on the same persistence path.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -17,21 +17,21 @@ import type { AgenticodingState } from "../state.js";
  * Module-level write lock state.
  *
  * Concurrent callers serialize by chaining on the prior promise. Reentrancy is
- * tracked per async call chain so a nested saveLedgerEntry fails explicitly
+ * tracked per async call chain so a nested saveNotebookPage fails explicitly
  * without rejecting unrelated concurrent writers that happen to overlap.
  */
 let writeLock: Promise<void> = Promise.resolve();
 const writeContext = new AsyncLocalStorage<true>();
 
 /** Reset write lock state. Only for test cleanup after concurrent runs. */
-export function resetLedgerWriteLock(): void {
+export function resetNotebookWriteLock(): void {
 	writeLock = Promise.resolve();
 }
 
 async function withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
 	if (writeContext.getStore()) {
 		throw new Error(
-			"Ledger write lock is not reentrant — saveLedgerEntry called from within its own critical section.",
+			"Notebook write lock is not reentrant — saveNotebookPage called from within its own critical section.",
 		);
 	}
 	let release: () => void;
@@ -47,33 +47,33 @@ async function withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
 	}
 }
 
-export function getEntryNames(state: AgenticodingState): string[] {
-	return Array.from(state.ledger.keys()).sort();
+export function getPageNames(state: AgenticodingState): string[] {
+	return Array.from(state.notebookPages.keys()).sort();
 }
 
 export const PREVIEW_MAX_CHARS = 80;
 const ELLIPSIS_LENGTH = 3;
 
-export function formatEntryPreview(content: string): string {
+export function formatPagePreview(content: string): string {
 	const firstLine = content.split("\n")[0] ?? "";
 	return firstLine.length > PREVIEW_MAX_CHARS
 		? firstLine.slice(0, PREVIEW_MAX_CHARS - ELLIPSIS_LENGTH) + "..."
 		: firstLine;
 }
 
-export function formatEntryList(state: AgenticodingState): string {
-	const names = getEntryNames(state);
+export function formatPageList(state: AgenticodingState): string {
+	const names = getPageNames(state);
 	if (names.length === 0) return "";
 
 	return names
 		.map((name) => {
-			const content = state.ledger.get(name)!;
-			return `  ${name}: ${formatEntryPreview(content)}`;
+			const content = state.notebookPages.get(name)!;
+			return `  ${name}: ${formatPagePreview(content)}`;
 		})
 		.join("\n");
 }
 
-export async function saveLedgerEntry(
+export async function saveNotebookPage(
 	pi: ExtensionAPI,
 	state: AgenticodingState,
 	name: string,
@@ -91,8 +91,8 @@ export async function saveLedgerEntry(
 			state.epoch = Date.now();
 		}
 
-		state.ledger.set(name, truncated.content);
-		pi.appendEntry("ledger-entry", {
+		state.notebookPages.set(name, truncated.content);
+		pi.appendEntry("notebook-entry", {
 			version: 1,
 			epoch: state.epoch,
 			name,
@@ -100,8 +100,8 @@ export async function saveLedgerEntry(
 		});
 
 		return {
-			entries: getEntryNames(state),
-			preview: formatEntryPreview(truncated.content),
+			entries: getPageNames(state),
+			preview: formatPagePreview(truncated.content),
 		};
 	});
 }

--- a/notebook/tools.ts
+++ b/notebook/tools.ts
@@ -1,9 +1,9 @@
 /**
- * Ledger tool definitions for the agenticoding extension.
+ * Notebook tool definitions for the agenticoding extension.
  *
- * Three tools: ledger_add (sequential, serialized write), ledger_get, ledger_list.
- * All read from the in-memory state.ledger Map and always return the current
- * list of entry names in both result text and details.
+ * Three tools: notebook_write (sequential, serialized write), notebook_read, notebook_index.
+ * All read from the in-memory state.notebookPages Map and always return the current
+ * list of page names in both result text and details.
  */
 
 import type { ExtensionAPI, ToolDefinition } from "@earendil-works/pi-coding-agent";
@@ -11,18 +11,18 @@ import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import type { AgenticodingState } from "../state.js";
 import { updateIndicators } from "../tui.js";
-import { formatEntryList, formatEntryPreview, getEntryNames, saveLedgerEntry } from "./store.js";
+import { formatPageList, formatPagePreview, getPageNames, saveNotebookPage } from "./store.js";
 
 // ── Factory ───────────────────────────────────────────────────────────
 
 /**
- * Creates ledger tool definitions (ledger_add, ledger_get, ledger_list).
+ * Creates notebook tool definitions (notebook_write, notebook_read, notebook_index).
  *
  * Shared by parent registration (withPromptHints=true) and child spawn
  * sessions (withPromptHints=false). The prompt hints (snippet, guidelines)
  * are only included for the parent — child agents don't need them.
  */
-export function createLedgerToolDefinitions(
+export function createNotebookToolDefinitions(
 	pi: ExtensionAPI,
 	state: AgenticodingState,
 	options?: { withPromptHints?: boolean; isStale?: () => boolean },
@@ -34,20 +34,23 @@ export function createLedgerToolDefinitions(
 		}
 	};
 
-	const ledgerAdd: ToolDefinition = {
-		name: "ledger_add",
-		label: "Ledger Add",
+	const notebookWrite: ToolDefinition = {
+		name: "notebook_write",
+		label: "Notebook Write",
 		description:
-			"Save or refine a compact continuity entry. " +
-			"Same name overwrites the previous entry (refinement). " +
+			"Write or refine a compact notebook page that grounds future contexts. " +
+			"One page covers one subject, thread, or subsystem. " +
+			"Same name overwrites the previous page (refinement). " +
 			"Writes are serialized via a process-local lock; same-name writes overwrite in completion order. " +
-			"Always returns the current list of up to date entries.",
+			"Always returns the current list of up to date pages.",
 		...(withHints
 			? {
-					promptSnippet: "Save or refine a compact continuity entry",
+					promptSnippet: "Write or refine a compact durable notebook page",
 					promptGuidelines: [
-						"Continuously maintain the ledger while you work. After meaningful reads, research, analysis, decisions, or milestones, either refine an existing entry, create a compact reusable entry, or consciously skip because nothing reusable was learned.",
-						"Prefer refining existing entries over creating many tiny ones. Do not try to make the ledger complete.",
+						"Reuse or refine an existing page when possible.",
+						"Prefer stable subject-oriented pages over workflow-phase pages.",
+						"Write for a fresh context: keep reusable facts, architecture, decisions, constraints, expensive discoveries, and durable open questions.",
+						"Avoid transient task state, scratch reasoning, transcripts, logs, or large tool output; the immediate next task belongs in handoff.",
 					],
 				}
 			: {}),
@@ -55,19 +58,19 @@ export function createLedgerToolDefinitions(
 		parameters: Type.Object({
 			name: Type.String({
 				description:
-					"Kebab-case entry identifier. Using an existing name overwrites that entry (refinement).",
+					"Kebab-case notebook page identifier. Prefer stable subject-oriented names; using an existing name overwrites that page (refinement).",
 			}),
 			content: Type.String({
 				description:
-					"Compact markdown. Capture only reusable facts, decisions, " +
-					"constraints, progress, and expensive discoveries. " +
-					"Truncated at 50KB / 2000 lines.",
+					"Compact markdown for one notebook page. Capture only durable, high-value " +
+					"grounding for one subject or thread, such as facts, architecture, decisions, constraints, " +
+					"open questions, or expensive discoveries. Compact sections like Facts / Architecture / Decisions / Constraints / Open questions work well. Truncated at 50KB / 2000 lines.",
 			}),
 		}),
 		renderCall(args, theme, _context) {
-			const preview = formatEntryPreview(args.content).trim();
+			const preview = formatPagePreview(args.content).trim();
 
-			let text = theme.fg("toolTitle", theme.bold("ledger_add ")) +
+			let text = theme.fg("toolTitle", theme.bold("notebook_write ")) +
 				theme.fg("accent", `"${args.name}"`);
 			if (preview) {
 				text += ": " + theme.fg("dim", preview);
@@ -90,7 +93,7 @@ export function createLedgerToolDefinitions(
 
 		async execute(_toolCallId, params, _signal, onUpdate, ctx) {
 			assertFresh();
-			const saved = await saveLedgerEntry(pi, state, params.name, params.content, assertFresh);
+			const saved = await saveNotebookPage(pi, state, params.name, params.content, assertFresh);
 			updateIndicators(ctx, state);
 
 			onUpdate?.({
@@ -104,9 +107,9 @@ export function createLedgerToolDefinitions(
 				content: [
 					{
 						type: "text",
-						text: `Saved ledger entry "${params.name}".` +
+						text: `Saved notebook page "${params.name}".` +
 							(saved.preview ? `\n${saved.preview}` : "") +
-							`\n\nEntries:\n${formatEntryList(state) || "(empty)"}`,
+							`\n\nNotebook Pages:\n${formatPageList(state) || "(empty)"}`,
 					},
 				],
 				details: { entries: saved.entries, preview: saved.preview },
@@ -114,18 +117,25 @@ export function createLedgerToolDefinitions(
 		},
 	};
 
-	const ledgerGet: ToolDefinition = {
-		name: "ledger_get",
-		label: "Ledger Get",
+	const notebookRead: ToolDefinition = {
+		name: "notebook_read",
+		label: "Notebook Read",
 		description:
-			"Retrieve a ledger entry's full body by name. " +
-			"Always returns the current list of entry names.",
+			"Read a notebook page's full body by name. " +
+			"Open one notebook page to recover state for that topic or thread. " +
+			"Always returns the current notebook page names.",
 		...(withHints
-			? { promptSnippet: "Fetch a ledger entry by name" }
+			? {
+					promptSnippet: "Read a notebook page by name",
+					promptGuidelines: [
+						"Use notebook_read to ground a fresh context, resume a subject, or check prior findings.",
+						"Open only relevant pages on demand; verify stale notes before relying on them.",
+					],
+				}
 			: {}),
 		parameters: Type.Object({
 			name: Type.String({
-				description: "Entry name to retrieve.",
+				description: "Notebook page name to retrieve.",
 			}),
 		}),
 		renderResult(result, { expanded }, theme, context) {
@@ -146,8 +156,8 @@ export function createLedgerToolDefinitions(
 
 		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			assertFresh();
-			const content = state.ledger.get(params.name);
-			const names = getEntryNames(state);
+			const content = state.notebookPages.get(params.name);
+			const names = getPageNames(state);
 
 			if (content === undefined) {
 				return {
@@ -155,8 +165,8 @@ export function createLedgerToolDefinitions(
 						{
 							type: "text",
 							text:
-								`Entry "${params.name}" not found.` +
-								`\n\nEntries:\n${formatEntryList(state) || "(empty)"}`,
+								`Notebook page "${params.name}" not found.` +
+								`\n\nNotebook Pages:\n${formatPageList(state) || "(empty)"}`,
 						},
 					],
 					details: { entries: names, found: false },
@@ -169,7 +179,7 @@ export function createLedgerToolDefinitions(
 						type: "text",
 						text:
 							`--- ${params.name} ---\n${content}\n` +
-							`---\nEntries:\n${formatEntryList(state) || "(empty)"}`,
+							`---\nNotebook Pages:\n${formatPageList(state) || "(empty)"}`,
 					},
 				],
 				details: { entries: names, found: true, body: content },
@@ -177,14 +187,21 @@ export function createLedgerToolDefinitions(
 		},
 	};
 
-	const ledgerList: ToolDefinition = {
-		name: "ledger_list",
-		label: "Ledger List",
+	const notebookIndex: ToolDefinition = {
+		name: "notebook_index",
+		label: "Notebook Index",
 		description:
-			"List all ledger entries as name + first-line preview. " +
-			"Always returns the current list of entry names.",
+			"Scan the notebook index as name + first-line preview. " +
+			"Use this like a pocket notebook index. " +
+			"Always returns the current notebook page names.",
 		...(withHints
-			? { promptSnippet: "List all ledger entries" }
+			? {
+					promptSnippet: "List pages via notebook index",
+					promptGuidelines: [
+						"Scan the index before new work, after handoff, before replanning, or when stuck.",
+						"Use the index to find relevant grounding pages, then open only those pages with notebook_read.",
+					],
+				}
 			: {}),
 		parameters: Type.Object({}),
 		renderResult(result, { expanded }, theme, _context) {
@@ -192,7 +209,7 @@ export function createLedgerToolDefinitions(
 			if (entries.length === 0) {
 				return new Text(theme.fg("dim", "\u{1F4D2} (empty)"), 0, 0);
 			}
-			let text = theme.fg("muted", `\u{1F4D2} ${entries.length} entr${entries.length === 1 ? "y" : "ies"}`);
+			let text = theme.fg("muted", `\u{1F4D2} ${entries.length} page${entries.length === 1 ? "" : "s"}`);
 			if (expanded) {
 				text += "\n" + theme.fg("dim", entries.join("\n"));
 			}
@@ -201,12 +218,12 @@ export function createLedgerToolDefinitions(
 
 		async execute() {
 			assertFresh();
-			const names = getEntryNames(state);
+			const names = getPageNames(state);
 			return {
 				content: [
 					{
 						type: "text",
-						text: `Entries:\n${formatEntryList(state) || "(empty)"}`,
+						text: `Notebook Pages:\n${formatPageList(state) || "(empty)"}`,
 					},
 				],
 				details: { entries: names },
@@ -214,16 +231,16 @@ export function createLedgerToolDefinitions(
 		},
 	};
 
-	return [ledgerAdd, ledgerGet, ledgerList];
+	return [notebookWrite, notebookRead, notebookIndex];
 }
 
 // ── Registration ──────────────────────────────────────────────────────
 
-export function registerLedgerTools(
+export function registerNotebookTools(
 	pi: ExtensionAPI,
 	state: AgenticodingState,
 ): void {
-	const tools = createLedgerToolDefinitions(pi, state, { withPromptHints: true });
+	const tools = createNotebookToolDefinitions(pi, state, { withPromptHints: true });
 	for (const tool of tools) {
 		pi.registerTool(tool);
 	}

--- a/notebook/topic-tool.ts
+++ b/notebook/topic-tool.ts
@@ -1,0 +1,53 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import type { AgenticodingState } from "../state.js";
+import { normalizeNotebookTopic, setActiveNotebookTopic } from "./topic.js";
+
+export function registerNotebookTopicTool(
+	pi: ExtensionAPI,
+	state: AgenticodingState,
+): void {
+	pi.registerTool({
+		name: "notebook_topic_set",
+		label: "Notebook Topic Set",
+		description:
+			"Set the active notebook topic for the current session. " +
+			"Use this to establish the current semantic frame when no topic is set yet. " +
+			"Human-set topics are authoritative and cannot be overridden by the agent.",
+		promptSnippet: "Set the active notebook topic for the current session",
+		promptGuidelines: [
+			"Use this early in a fresh session when no active notebook topic exists yet.",
+			"Do not use this to override a human-set topic. If the work no longer fits the current topic, prefer handoff instead.",
+		],
+		parameters: Type.Object({
+			topic: Type.String({
+				description: "Short stable notebook topic name for the current semantic frame.",
+			}),
+		}),
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+			const normalized = normalizeNotebookTopic(params.topic);
+			if (state.activeNotebookTopic) {
+				if (state.activeNotebookTopic !== normalized) {
+					throw new Error(
+						state.activeNotebookTopicSource === "human"
+							? "Human-set notebook topic is authoritative. Use handoff instead of overriding it."
+							: "Active notebook topic already exists. Use handoff instead of changing it mid-session.",
+					);
+				}
+				return {
+					content: [{ type: "text", text: `Notebook topic already set to \"${state.activeNotebookTopic}\".` }],
+					details: {
+						topic: state.activeNotebookTopic,
+						source: state.activeNotebookTopicSource,
+						changed: false,
+					},
+				};
+			}
+			const result = setActiveNotebookTopic(state, params.topic, "agent");
+			return {
+				content: [{ type: "text", text: `Active notebook topic: \"${result.current}\".` }],
+				details: { topic: result.current, source: "agent" as const, changed: result.changed },
+			};
+		},
+	});
+}

--- a/notebook/topic.ts
+++ b/notebook/topic.ts
@@ -1,0 +1,52 @@
+import type { AgenticodingState } from "../state.js";
+
+export type NotebookTopicSource = "human" | "agent";
+
+export interface NotebookTopicBoundaryHint {
+	from: string | null;
+	to: string;
+	source: NotebookTopicSource;
+}
+
+export function normalizeNotebookTopic(input: string): string {
+	return input
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 80);
+}
+
+export function setActiveNotebookTopic(
+	state: AgenticodingState,
+	topic: string,
+	source: NotebookTopicSource,
+): { changed: boolean; previous: string | null; current: string; boundaryHint: NotebookTopicBoundaryHint | null } {
+	const normalized = normalizeNotebookTopic(topic);
+	if (!normalized) {
+		throw new Error("Notebook topic cannot be empty.");
+	}
+
+	const previous = state.activeNotebookTopic;
+	const changed = previous !== normalized;
+	state.activeNotebookTopic = normalized;
+	state.activeNotebookTopicSource = source;
+
+	const boundaryHint = changed && previous !== null
+		? { from: previous, to: normalized, source }
+		: null;
+	state.pendingTopicBoundaryHint = boundaryHint;
+
+	return {
+		changed,
+		previous,
+		current: normalized,
+		boundaryHint,
+	};
+}
+
+export function clearActiveNotebookTopic(state: AgenticodingState): void {
+	state.activeNotebookTopic = null;
+	state.activeNotebookTopicSource = null;
+	state.pendingTopicBoundaryHint = null;
+}

--- a/spawn/index.ts
+++ b/spawn/index.ts
@@ -2,7 +2,7 @@
  * Spawn tool for the agenticoding extension.
  *
  * Creates an isolated in-memory child AgentSession for focused subtask execution.
- * Children inherit the parent's model, thinking level, cwd, and ledger access.
+ * Children inherit the parent's model, thinking level, cwd, and notebook access.
  * Children do not inherit the spawn tool (recursion prevention).
  *
  * Spawn is context isolation, not a security boundary. Child agents are trusted
@@ -24,8 +24,8 @@ import {
 import { StringEnum } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import type { AgenticodingState } from "../state.js";
-import { formatEntryList } from "../ledger/store.js";
-import { createLedgerToolDefinitions } from "../ledger/tools.js";
+import { formatPageList } from "../notebook/store.js";
+import { createNotebookToolDefinitions } from "../notebook/tools.js";
 import {
 	renderSpawnCall,
 	renderSpawnResult,
@@ -137,8 +137,8 @@ export function buildChildToolNames(
 
 const SPAWN_DESCRIPTION =
 	"Spawn an isolated child agent for a focused subtask. " +
-	"Child inherits parent model, thinking level, cwd, supported built-in tools, and shared ledger tools; children cannot spawn further children. " +
-	"Reference ledger entries by name — child will ledger_get them on demand.";
+	"Child inherits parent model, thinking level, cwd, supported built-in tools, and shared notebook tools; children cannot spawn further children. " +
+	"Reference notebook pages by name — child will notebook_read them on demand.";
 
 const SPAWN_PROMPT_SNIPPET = "Spawn a focused subtask agent";
 
@@ -149,8 +149,8 @@ const SPAWN_PROMPT_GUIDELINES = [
 const SPAWN_PARAMETERS = Type.Object({
 	prompt: Type.String({
 		description:
-			"Self-contained task description. Reference ledger entries by name — " +
-			"child will ledger_get them on demand.",
+			"Self-contained task description. Reference notebook pages by name — " +
+			"child will notebook_read them on demand.",
 	}),
 	thinking: StringEnum(
 		["off", "minimal", "low", "medium", "high", "xhigh"] as const,
@@ -166,10 +166,10 @@ const SPAWN_PARAMETERS = Type.Object({
 /**
  * Build the custom tool set for child agent sessions.
  *
- * Produces ledger tools (add/get/list). Children do not receive the spawn
+ * Produces notebook tools (write/read/index). Children do not receive the spawn
  * tool to prevent the LLM from attempting recursion.
  *
- * All tools read/write the shared parent state so ledger entries are visible
+ * All tools read/write the shared parent state so notebook pages are visible
  * across parent and child contexts.
  */
 export function createChildTools(
@@ -177,7 +177,7 @@ export function createChildTools(
 	state: AgenticodingState,
 	options?: { isStale?: () => boolean },
 ): ToolDefinition[] {
-	return createLedgerToolDefinitions(pi, state, { isStale: options?.isStale });
+	return createNotebookToolDefinitions(pi, state, { isStale: options?.isStale });
 }
 
 
@@ -221,16 +221,18 @@ export async function executeSpawn(
 
 	const childThinking: ThinkingValue = params.thinking ?? defaultThinking;
 
-	const listing = formatEntryList(state);
-	const ledgerListing = listing
-		? "Available ledger entries:\n" + listing
-		: "No ledger entries.";
+	const listing = formatPageList(state);
+	const notebookListing = listing
+		? "Available notebook pages:\n" + listing
+		: "No notebook pages.";
 	const fullPrompt =
 		`You are a focused child agent spawned by a parent agent. ` +
 		`You have the same authority as the parent. ` +
 		`Children cannot spawn further children. ` +
 		`Your result will be read by the parent, so be concise and complete.\n\n` +
-		`${ledgerListing}\n\n` +
+		`${notebookListing}\n\n` +
+		`If you write notebook pages, store only durable grounding knowledge for future contexts. ` +
+		`Keep transient task state in your final reply to the parent.\n\n` +
 		`## Task\n\n${params.prompt}\n\n` +
 		`When complete, provide a concise summary of findings. ` +
 		`Keep the result under ${CHILD_MAX_LINES} lines / ${(CHILD_MAX_BYTES / 1024).toFixed(0)}KB.`;
@@ -384,10 +386,10 @@ export async function executeSpawn(
  *
  * Creates a ToolDefinition that spawns an isolated child AgentSession
  * for focused subtasks. Children inherit the parent model, thinking
- * level, cwd, and ledger access.
+ * level, cwd, and notebook access.
  *
  * @param pi - Extension API instance for tool registration
- * @param state - Shared session state (child sessions, epoch, ledger)
+ * @param state - Shared session state (child sessions, epoch, notebook)
  * @param sessionFactory - Optional test seam for mocking createAgentSession
  */
 export function registerSpawnTool(

--- a/state.ts
+++ b/state.ts
@@ -104,7 +104,7 @@ export function createState(): AgenticodingState {
 export function resetState(state: AgenticodingState): void {
 	state.childSessionEpoch++;
 	state.notebookPages.clear();
-	state.epoch = 0;
+	state.epoch = 0; // sentinel: 0 = not yet initialized; set to Date.now() on first write
 	state.activeNotebookTopic = null;
 	state.activeNotebookTopicSource = null;
 	state.pendingTopicBoundaryHint = null;

--- a/state.ts
+++ b/state.ts
@@ -8,10 +8,10 @@
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 
 export interface AgenticodingState {
-	/** Compact ledger entries keyed by kebab-case name */
-	ledger: Map<string, string>;
+	/** Compact notebook pages keyed by kebab-case name */
+	notebookPages: Map<string, string>;
 
-	/** Monotonically increasing epoch, set on first ledger_add */
+	/** Monotonically increasing epoch, set on first notebook_write */
 	epoch: number;
 
 	/** Last context usage percent from getContextUsage() */
@@ -57,7 +57,7 @@ export function createState(): AgenticodingState {
 	const childSessions = new Map<string, AgentSession>();
 	const liveChildSessions = new Map<string, AgentSession>();
 	const state: AgenticodingState = {
-		ledger: new Map(),
+		notebookPages: new Map(),
 		epoch: 0,
 		lastContextPercent: null,
 		pendingHandoff: null,
@@ -87,7 +87,7 @@ export function createState(): AgenticodingState {
 /** Reset all state. Used on /new or session reset. */
 export function resetState(state: AgenticodingState): void {
 	state.childSessionEpoch++;
-	state.ledger.clear();
+	state.notebookPages.clear();
 	state.epoch = 0;
 	state.lastContextPercent = null;
 	state.pendingHandoff = null;
@@ -104,6 +104,6 @@ export function abortAndClearChildSessions(state: AgenticodingState): void {
 	state.childSessions.clear();
 	state.liveChildSessions.clear();
 	for (const [session, id] of seen) {
-		session.abort().catch(e => console.warn("[spawn] abort failed:", id, e));
+		session.abort().catch((e: unknown) => console.warn("[spawn] abort failed:", id, e));
 	}
 }

--- a/state.ts
+++ b/state.ts
@@ -14,6 +14,19 @@ export interface AgenticodingState {
 	/** Monotonically increasing epoch, set on first notebook_write */
 	epoch: number;
 
+	/** Current semantic frame for topic-aware spawn vs handoff decisions. */
+	activeNotebookTopic: string | null;
+
+	/** Whether the current topic came from the human or the agent. */
+	activeNotebookTopicSource: "human" | "agent" | null;
+
+	/** One-shot boundary cue consumed by the next LLM call after a topic change. */
+	pendingTopicBoundaryHint: {
+		from: string | null;
+		to: string;
+		source: "human" | "agent";
+	} | null;
+
 	/** Last context usage percent from getContextUsage() */
 	lastContextPercent: number | null;
 
@@ -59,6 +72,9 @@ export function createState(): AgenticodingState {
 	const state: AgenticodingState = {
 		notebookPages: new Map(),
 		epoch: 0,
+		activeNotebookTopic: null,
+		activeNotebookTopicSource: null,
+		pendingTopicBoundaryHint: null,
 		lastContextPercent: null,
 		pendingHandoff: null,
 		pendingRequestedHandoff: null,
@@ -89,6 +105,9 @@ export function resetState(state: AgenticodingState): void {
 	state.childSessionEpoch++;
 	state.notebookPages.clear();
 	state.epoch = 0;
+	state.activeNotebookTopic = null;
+	state.activeNotebookTopicSource = null;
+	state.pendingTopicBoundaryHint = null;
 	state.lastContextPercent = null;
 	state.pendingHandoff = null;
 	state.pendingRequestedHandoff = null;

--- a/system-prompt.ts
+++ b/system-prompt.ts
@@ -2,7 +2,7 @@
  * Context management system prompt primer.
  *
  * Injected via before_agent_start into the system prompt.
- * Teaches the LLM about spawn, ledger, and handoff primitives.
+ * Teaches the LLM about spawn, notebook, and handoff primitives.
  */
 
 export const CONTEXT_PRIMER = `
@@ -24,36 +24,54 @@ Delegate isolated work to child agents. They are trusted extensions of you,
 with their own context and the same authority. You receive only condensed
 results. Parent context stays at orchestration level. Siblings run in parallel.
 
-### Ledger — sparse continuity cache
-Continuously maintain the ledger while you work. After meaningful reads,
-research, analysis, decisions, or milestones, either update/refine a ledger
-entry now or consciously skip because nothing reusable was learned. Prefer
-refining existing entries over creating many tiny ones. The current ledger
-listing is available above. Reference entries by name; fetch via ledger_get on
-demand. Never pre-load bodies.
+### Notebook — durable cross-context grounding
+Treat the notebook as durable grounding for future contexts. Each page covers
+one subject, thread, or subsystem. Prefer refining a few living pages organized
+by subject rather than workflow phase. Store only reusable knowledge worth
+carrying across resets: verified facts, architecture learned, decisions and
+rationale, constraints, expensive discoveries, and durable open questions.
 
-### Handoff — complete the picture, then continue cleanly
+Treat notebook_index as the notebook index. Scan it at task start, after handoff,
+before replanning, or when stuck. Use notebook_read to open only relevant pages.
+Use them to ground a fresh context, avoid repeated work, and resume a subject
+quickly. Verify stale notes before relying on them. Avoid raw transcripts, logs,
+or large tool output. Reference pages by name; fetch on demand; never pre-load
+bodies.
+
+### Active notebook topic — current semantic frame
+The active notebook topic names the current high-level frame for this session.
+If the current work still fits that topic, prefer spawn for isolated noisy
+subtasks so the parent stays focused. If the work no longer fits that topic,
+prefer handoff over dragging stale context forward. After handoff, assign a
+fresh topic again in the next context.
+
+### Handoff — distilled next task
 When the job changes, or when context is noisy past the ~30% heuristic, use
 handoff to finish extracting what matters from the current context before the
-cut. Save reusable state to the ledger when useful, then draft a handoff brief
-that preserves the important knowledge still missing from the ledger.
-Handoff compacts the active session around that brief so the next turn starts
-in a clean context with the right picture already in view. Full history remains
-in the session file for the user.
+cut. Save durable reusable knowledge to the notebook first, then draft a
+handoff brief that carries only the situational context still missing: current
+state, blockers, unresolved questions, failed paths worth avoiding, and next
+steps. Handoff compacts the active session around that brief so the next turn
+starts in a clean context with the right direction already in view. Full history
+remains in the session file for the user.
 
-Use any structure that keeps the next work unambiguous. Include the current
-state, important findings, unresolved questions, failed paths worth avoiding,
-next steps, refs, constraints, and spawn ideas when useful. The handoff should
-help the next context start well without re-deriving what you already learned.
+The next context should use the notebook for grounding and the handoff brief
+for direction. Reference notebook pages by name; do not duplicate their content
+in the brief. The handoff should help the next context start well without
+re-deriving what you already learned.
 
 ### Rules
-- Maintain the ledger as a constant working process; do not wait for handoff
-- Cache reusable state in the ledger; handoff should also capture the missing context that has not been recorded yet
-- Prefer refining existing entries over creating many tiny ones
-- After meaningful work, either update/refine the ledger or intentionally skip
-- Reference ledger entries by name when useful; fetch bodies on demand
+- Maintain the notebook deliberately; update it when you learn durable knowledge worth carrying across contexts
+- One page = one subject, thread, or subsystem
+- Prefer subject pages over workflow-phase pages
+- Use notebook_index as the index before starting, resuming, or replanning
+- Use notebook_read to open only relevant pages
+- Keep pages compact; avoid raw dumps, repeated tool output, scratch reasoning, and local task state
+- Use compact sections such as Facts / Architecture / Decisions / Constraints / Open questions when helpful
+- Separate facts, guesses, and decisions when useful
 - Use spawn to delegate isolated subtasks when it helps; parent orchestrates and merges results
+- Treat the active notebook topic as the current semantic frame: same topic → spawn bias, different topic → handoff bias
 - Call handoff at job boundaries: research→execution, planning→execution
-- Past ~30%, consider handoff when the phase is done or context noise is hurting focus
-- After handoff, ledger_get entries as needed — not all at once
+- Use handoff to pass the distilled next task and immediate starting state
+- After handoff, fetch only the pages you need and assign a fresh topic again
 `.trim();

--- a/tui.ts
+++ b/tui.ts
@@ -19,10 +19,10 @@ export const WIDGET_KEY_WARNING = "agenticoding-warning";
 /** Status bar key for context usage percentage. */
 export const STATUS_KEY_CTX = "agenticoding-ctx";
 
-/** Status bar key for ledger entry count. */
-export const STATUS_KEY_LEDGER = "agenticoding-ledger";
+/** Status bar key for notebook page count. */
+export const STATUS_KEY_NOTEBOOK = "agenticoding-notebook";
 
-/** Update TUI indicators: context usage, ledger count, warning widget. */
+/** Update TUI indicators: context usage, notebook count, warning widget. */
 export function updateIndicators(ctx: ExtensionContext, state: AgenticodingState): void {
 	if (!ctx.hasUI) return;
 
@@ -38,9 +38,9 @@ export function updateIndicators(ctx: ExtensionContext, state: AgenticodingState
 		ctx.ui.setStatus(STATUS_KEY_CTX, theme.fg("dim", "ctx --%"));
 	}
 
-	// Ledger count — show 📒 0 in dim tone when empty so the feature is discoverable
-	const count = state.ledger.size;
-	ctx.ui.setStatus(STATUS_KEY_LEDGER, count > 0
+	// Notebook page count — show 📒 0 in dim tone when empty so the feature is discoverable
+	const count = state.notebookPages.size;
+	ctx.ui.setStatus(STATUS_KEY_NOTEBOOK, count > 0
 		? `\u{1F4D2} ${count}`
 		: theme.fg("dim", "\u{1F4D2} 0"),
 	);

--- a/tui.ts
+++ b/tui.ts
@@ -22,7 +22,10 @@ export const STATUS_KEY_CTX = "agenticoding-ctx";
 /** Status bar key for notebook page count. */
 export const STATUS_KEY_NOTEBOOK = "agenticoding-notebook";
 
-/** Update TUI indicators: context usage, notebook count, warning widget. */
+/** Status bar key for the active notebook topic. */
+export const STATUS_KEY_TOPIC = "agenticoding-topic";
+
+/** Update TUI indicators: context usage, notebook count, topic, warning widget. */
 export function updateIndicators(ctx: ExtensionContext, state: AgenticodingState): void {
 	if (!ctx.hasUI) return;
 
@@ -45,11 +48,21 @@ export function updateIndicators(ctx: ExtensionContext, state: AgenticodingState
 		: theme.fg("dim", "\u{1F4D2} 0"),
 	);
 
+	// Active notebook topic — show a dim placeholder when unset so the frame is discoverable
+	ctx.ui.setStatus(
+		STATUS_KEY_TOPIC,
+		state.activeNotebookTopic
+			? `\u{1F9ED} ${state.activeNotebookTopic}`
+			: theme.fg("dim", "\u{1F9ED} -"),
+	);
+
 	// High-context warning widget (above editor)
 	if (usage && usage.percent !== null && usage.percent >= 70) {
+		const warning = state.activeNotebookTopic
+			? `Context at ${Math.round(usage.percent)}% — use topic fit: same topic → spawn, different topic → handoff`
+			: `Context at ${Math.round(usage.percent)}% — no active topic; handoff soon unless you can assign one cleanly`;
 		ctx.ui.setWidget(WIDGET_KEY_WARNING, [
-			theme.fg("error", "\u26A0 ") +
-				theme.fg("warning", `Context at ${Math.round(usage.percent)}% — consider handoff`),
+			theme.fg("error", "\u26A0 ") + theme.fg("warning", warning),
 		]);
 	} else {
 		ctx.ui.setWidget(WIDGET_KEY_WARNING, undefined);

--- a/watchdog.ts
+++ b/watchdog.ts
@@ -12,28 +12,42 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import type { AgenticodingState } from "./state.js";
 import { STATUS_KEY_HANDOFF } from "./tui.js";
 
-/** Build a nudge string with the exact percent interpolated. */
-export function buildNudge(percent: number): string {
-	const pct = Math.round(percent);
+export function buildNudge(state: Pick<AgenticodingState, "activeNotebookTopic" | "pendingTopicBoundaryHint">, percent: number | null): string {
+	const pct = percent === null ? null : Math.round(percent);
+	const topic = state.activeNotebookTopic;
+	const boundary = state.pendingTopicBoundaryHint;
 
-	if (pct >= 70) {
-		return `Context at ${pct}% — deep in the degraded zone. Compaction may trigger soon
-(emergency summarization at ~90%). Prefer a deliberate handoff now: save
-reusable state to the ledger, draft a clear next-task brief, and call handoff.`;
+	if (boundary) {
+		return `Notebook topic changed from ${boundary.from ?? "(unset)"} to ${boundary.to}.
+Treat this as a strong task-boundary signal. Prefer a deliberate handoff before
+continuing under the new topic: save durable findings to the notebook, draft a
+concise situational brief, and call handoff. Only continue inline if this was
+merely a rename rather than a real pivot.`;
 	}
 
-	if (pct >= 50) {
-		return `Context at ${pct}% — well past the primacy-zone heuristic. If the current job is
-done or the context is noisy, consider a handoff soon. Save reusable state to
-the ledger and draft a concise but sufficiently detailed brief for what comes
-next.`;
+	const contextLead = pct === null
+		? "Topic-aware context reminder."
+		: pct >= 70
+			? `Context at ${pct}% — topic discipline is urgent.`
+			: pct >= 50
+				? `Context at ${pct}% — topic discipline matters now.`
+				: `Context at ${pct}% — choose your next step by topic fit.`;
+
+	if (topic) {
+		const urgency = pct !== null && pct >= 70
+			? "If the work no longer fits this topic, prefer a deliberate handoff now. If it still fits and only a focused noisy branch is needed, spawn it instead of polluting the parent context."
+			: "If the current work still fits this topic, prefer spawn for isolated noisy subtasks. If it no longer fits, prefer handoff instead of dragging stale context forward.";
+		return `${contextLead}
+Active notebook topic: ${topic}.
+Use the topic as the current semantic frame. ${urgency}
+Save durable findings to the notebook before handoff.`;
 	}
 
-	// 30-50%
-	return `Context at ${pct}% — past the primacy-zone heuristic. One context, one job.
-If you're mid-job and still clear, continue. If the current phase is complete
-or the context is noisy, consider a handoff and draft a clear brief for what
-comes next.`;
+	const noTopicUrgency = pct !== null && pct >= 70
+		? "Assign a fresh topic in the next clean context after handoff."
+		: "Assign a short stable topic soon. If the work stays within that topic, prefer spawn for noisy subtasks. If the work shifts beyond it, prefer handoff.";
+	return `${contextLead}
+No active notebook topic is set. ${noTopicUrgency}`;
 }
 
 /**


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our Discord!

---

## Summary

This PR renames the `ledger` subsystem to `notebook`, upgrades its semantics from a sparse continuity cache to durable subject-oriented grounding, and introduces a topic-awareness layer that uses the active semantic frame to drive spawn-vs-handoff decisions with boundary detection.

### What changed

**Renamed `ledger/` → `notebook/`** — the directory, state property (`state.ledger` → `state.notebookPages`), all public tools (`ledger_add` → `notebook_write`, `ledger_get` → `notebook_read`, `ledger_list` → `notebook_index`), and the interactive `/ledger` command → `/notebook`. Backward-compatible rehydration scans for both `ledger-entry` and `notebook-entry` persisted custom types, so no data loss across upgrades.

**Semantic upgrade** — the notebook is now framed as durable cross-context grounding organized by subject/thread, not a running stream-of-consciousness cache. The CONTEXT_PRIMER, tool descriptions, and prompt guidelines all steer toward pages that outlive a single session: architecture, decisions, constraints, open questions. Transient task state belongs in the handoff brief, not the notebook.

**New topic-awareness layer** — `notebook/topic.ts` + `notebook/topic-tool.ts` add an `activeNotebookTopic` field to state, a `notebook_topic_set` tool, and a `pendingTopicBoundaryHint` mechanism. When the topic changes, the watchdog emits a boundary nudge (even below the 30% context heuristic) recommending a deliberate handoff. The TUI shows the topic in the status bar (`🧭 topic`), and the high-context warning widget is now topic-aware. Handoff compaction automatically clears the active topic so the next context starts fresh.

### Breaking changes

- **All ledger public API symbols renamed**: migrate any extension code or stored session references from `ledger_*` to `notebook_*` tool names.
- **State shape**: `state.ledger` → `state.notebookPages` (affects direct state access).
- **`/ledger`** TUI command renamed to `/notebook`; the command now also accepts a topic argument (`/notebook <topic>`) to set the active frame.
- The watchdog nudge format has changed: it no longer emits the old percent-only reminders and instead generates topic-aware guidance. Any code parsing nudge text programmatically will need updating.

### Value

The rename signals a real semantic upgrade — the notebook is a carefully curated set of durable pages for cross-context reuse, not a firehose of continuity scribbles. The topic-awareness layer gives the agent a lightweight frame for context-boundary decisions: stay and spawn within a topic, handoff when the topic shifts. This directly reduces the amount of stale context dragged across job boundaries, and the boundary hint mechanism catches mid-task pivots that would otherwise silently degrade context quality.

---

Attached is an agent optimized description of the changes in this PR - [AGENT_REVIEW.md](https://github.com/user-attachments/files/28223452/AGENT_REVIEW.md)
